### PR TITLE
Refactor: Introduce Custom Playwright Fixtures Across All Test Specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # playwright-webdriveruni
 
-![E2E Tests](https://github.com/SantiagoBernal/playwright-webdriveruni/actions/workflows/e2e.yml/badge.svg)
-
 An end-to-end test automation suite for [WebdriverUniversity.com](https://webdriveruniversity.com), built with **Playwright**, **TypeScript**, and **GitHub Actions**.
 
 ---

--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ An end-to-end test automation suite for [WebdriverUniversity.com](https://webdri
 
 ## Overview
 
-This project automates UI testing across the full range of interactive features offered by WebdriverUniversity — a dedicated practice site for web automation engineers. It covers 17 test scenarios including form handling, iFrames, drag-and-drop, file uploads, login flows, popups, data tables, and more.
+This project automates UI testing across the full range of interactive features offered by WebdriverUniversity, a dedicated practice site for web automation engineers. It covers 17 test scenarios including form handling, iFrames, drag-and-drop, file uploads, login flows, popups, data tables, and more.
 
 **Tech Stack:**
-- [Playwright](https://playwright.dev/) `^1.43.1` — E2E test framework
-- TypeScript — type-safe test authoring
-- [@faker-js/faker](https://fakerjs.dev/) — dynamic test data generation
-- [dotenv](https://github.com/motdotla/dotenv) — environment variable management
-- GitHub Actions — CI/CD pipeline with sharded parallel execution
+- [Playwright](https://playwright.dev/) `^1.43.1`, E2E test framework
+- TypeScript, type-safe test authoring
+- [@faker-js/faker](https://fakerjs.dev/), dynamic test data generation
+- [dotenv](https://github.com/motdotla/dotenv), environment variable management
+- GitHub Actions, CI/CD pipeline with sharded parallel execution
 
 ---
 
@@ -31,6 +31,8 @@ playwright-webdriveruni/
 │   ├── base.page.ts                 # Abstract base class
 │   └── *.page.ts                    # One POM per feature
 ├── tests/                           # Test specs (17 files)
+│   ├── fixtures/
+│   │   └── index.ts                 # Custom Playwright fixtures
 │   └── *.spec.ts
 ├── snapshots/                       # Visual regression baselines
 ├── test-results/                    # Local test output (gitignored)
@@ -61,7 +63,72 @@ tests/actions.spec.ts        <-->  pages/actions.page.ts
 ...
 ```
 
-This means selectors live only in page objects — never directly in tests.
+This means selectors live only in page objects, never directly in tests.
+
+---
+
+## Custom Fixtures
+
+All tests import `test` and `expect` from `tests/fixtures/index.ts` instead of directly from `@playwright/test`. This single file uses Playwright's `test.extend()` API to provide a ready-to-use page object for every feature, eliminating the repetitive `beforeEach` navigation and manual page construction that would otherwise appear in every test.
+
+**Before fixtures:**
+```typescript
+import { test, expect } from "@playwright/test";
+import { HomePage } from "../pages/home.page";
+
+test.describe("Login Portal Tests", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+  });
+
+  test("should log in successfully", async ({ page }) => {
+    const homePage = new HomePage(page);
+    const loginPage = await homePage.openLoginPortal();
+    await loginPage.login(process.env.USERNAME, process.env.PASSWORD);
+  });
+});
+```
+
+**After fixtures:**
+```typescript
+import { test, expect } from "./fixtures";
+
+test.describe("Login Portal Tests", () => {
+  test("should log in successfully", async ({ loginPortalPage }) => {
+    await loginPortalPage.login(process.env.USERNAME, process.env.PASSWORD);
+  });
+});
+```
+
+Each fixture navigates to the home page, opens the correct popup, and returns a fully constructed page object, scoped per test for complete isolation.
+
+### Available Fixtures
+
+| Fixture | Page Opened |
+|---|---|
+| `homePage` | Home page (no popup) |
+| `loginPortalPage` | Login Portal |
+| `contactUsPage` | Contact Us |
+| `clickButtonsPage` | Button Clicks |
+| `toDoListPage` | To Do List |
+| `pageObjectModelPage` | Page Object Model |
+| `textAffectsPage` | Accordion & Text Affects |
+| `dropdownButtonsPage` | Dropdown, Checkboxes & Radio Buttons |
+| `ajaxLoaderPage` | Ajax Loader |
+| `actionsPage` | Actions (drag & drop, hover, etc.) |
+| `scrollingAroundPage` | Scrolling Around |
+| `popupAlertsPage` | Popup & Alerts |
+| `iframePage` | IFrame |
+| `hiddenElementsPage` | Hidden Elements |
+| `dataTablesButtonsPage` | Data, Tables & Button States |
+| `autocompleteTextPage` | Autocomplete Textfield |
+| `fileUploadPage` | File Upload |
+
+### Adding a New Fixture
+
+1. Add the new page type to the `AppFixtures` type in [tests/fixtures/index.ts](tests/fixtures/index.ts)
+2. Add the fixture implementation calling the corresponding `homePage.open*()` method
+3. Import the new fixture in your spec: `import { test, expect } from "./fixtures";`
 
 ---
 
@@ -180,7 +247,7 @@ Only **Chromium** is enabled. Firefox and WebKit projects exist in the config bu
 
 ## CI/CD Pipeline
 
-### `e2e.yml` — Main E2E Tests
+### `e2e.yml`, Main E2E Tests
 
 **Triggers:** Push to `main`, pull requests targeting `main`
 
@@ -211,9 +278,9 @@ Shard 4/4  ──┘
 
 ---
 
-### `update-snapshots.yml` — Visual Snapshot Updates
+### `update-snapshots.yml`, Visual Snapshot Updates
 
-**Trigger:** Manual (`workflow_dispatch`) — select the target branch
+**Trigger:** Manual (`workflow_dispatch`), select the target branch
 
 **What it does:**
 1. Checks out the specified branch

--- a/tests/actions.spec.ts
+++ b/tests/actions.spec.ts
@@ -1,17 +1,9 @@
-import { test, expect } from "@playwright/test";
-import { HomePage } from "../pages/home.page";
+import { test, expect } from "./fixtures";
 
 test.describe("Actions - Happy Path", () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto("/");
-  });
-
   test("Verify Page URL, Header, Title, Sections and Footer", async ({
-    page
+    actionsPage
   }) => {
-    const homePage = new HomePage(page);
-    const actionsPage = await homePage.openActions();
-
     // Verify url and Header title
     await expect(actionsPage.page).toHaveURL(/Actions/i);
     await expect(actionsPage.pageNavTitle).toContainText(/WebdriverUniversity.com/);
@@ -27,10 +19,7 @@ test.describe("Actions - Happy Path", () => {
     await expect(actionsPage.footer).toContainText("Copyright");
   });
 
-  test("Drag and Drop section should work correctly", async ({ page }) => {
-    const homePage = new HomePage(page);
-    const actionsPage = await homePage.openActions();
-
+  test("Drag and Drop section should work correctly", async ({ actionsPage }) => {
     // Define drag and drop elements
     const dragDropSection = actionsPage.dragDropSectionFirst;
     const draggable = actionsPage.draggable(dragDropSection);
@@ -83,10 +72,7 @@ test.describe("Actions - Happy Path", () => {
     await expect(droppable).toContainText("Dropped!");
   });
 
-  test("Double Click section should work correctly", async ({ page }) => {
-    const homePage = new HomePage(page);
-    const actionsPage = await homePage.openActions();
-
+  test("Double Click section should work correctly", async ({ actionsPage }) => {
     const dblClickBttn = actionsPage.doubleClickButton;
 
     // Verify inital state
@@ -102,10 +88,7 @@ test.describe("Actions - Happy Path", () => {
     await expect(dblClickBttn).toHaveClass("div-double-click");
   });
 
-  test("Hover Over section should work correctly", async ({ page }) => {
-    const homePage = new HomePage(page);
-    const actionsPage = await homePage.openActions();
-
+  test("Hover Over section should work correctly", async ({ actionsPage }) => {
     const hoverFirst = actionsPage.hoverButtons.nth(0);
     const hoverSecond = actionsPage.hoverButtons.nth(1);
     const hoverThird = actionsPage.hoverButtons.nth(2);
@@ -164,10 +147,7 @@ test.describe("Actions - Happy Path", () => {
     await fourthAlert.click();
   });
 
-  test("Click and Hold section should work correclty", async ({ page }) => {
-    const homePage = new HomePage(page);
-    const actionsPage = await homePage.openActions();
-
+  test("Click and Hold section should work correclty", async ({ actionsPage }) => {
     const clickAndHoldBttn = actionsPage.clickAndHoldBox;
 
     // Verify Initial State
@@ -195,16 +175,9 @@ test.describe("Actions - Happy Path", () => {
 });
 
 test.describe("Actions - Edge Path", () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto("/");
-  });
-
   test("Drag and Drop section - Releasing drag outside the drop secion should not change the color", async ({
-    page
+    actionsPage
   }) => {
-    const homePage = new HomePage(page);
-    const actionsPage = await homePage.openActions();
-
     const dragDropSection = actionsPage.dragDropSectionFirst;
     const draggable = actionsPage.draggable(dragDropSection);
     const droppable = actionsPage.droppable(dragDropSection);
@@ -222,11 +195,8 @@ test.describe("Actions - Edge Path", () => {
   });
 
   test("Double Click section - Clicking once should not change click color", async ({
-    page
+    actionsPage
   }) => {
-    const homePage = new HomePage(page);
-    const actionsPage = await homePage.openActions();
-
     const dblClickBttn = actionsPage.doubleClickButton;
 
     // Perform just one click and verify the color does not change

--- a/tests/ajax.loader.spec.ts
+++ b/tests/ajax.loader.spec.ts
@@ -1,78 +1,64 @@
-import { test, expect } from "@playwright/test";
-import { HomePage } from "../pages/home.page";
+import { test, expect } from "./fixtures";
 
 test.describe("Ajax Loader - Only Path", () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto("/");
-  });
-
-  test("Verify URL and header", async ({ page }) => {
-    const homePage = new HomePage(page);
-    const ajaxPage = await homePage.openAjaxLoader();
-
+  test("Verify URL and header", async ({ ajaxLoaderPage }) => {
     // Verify url and Header title
-    await expect(ajaxPage.page).toHaveURL(/Ajax-Loader/i);
-    await expect(ajaxPage.navTitle).toContainText(/WebdriverUniversity.com/);
+    await expect(ajaxLoaderPage.page).toHaveURL(/Ajax-Loader/i);
+    await expect(ajaxLoaderPage.navTitle).toContainText(/WebdriverUniversity.com/);
   });
 
   test("Verify Ajax loader is visible then button appears", async ({
-    page
+    ajaxLoaderPage
   }) => {
-    const homePage = new HomePage(page);
-    const ajaxPage = await homePage.openAjaxLoader();
-
     // Verify initial state loader visible button not visible
-    await expect(ajaxPage.loader).toBeVisible();
-    await expect(ajaxPage.loader).not.toHaveCSS("display", "none");
+    await expect(ajaxLoaderPage.loader).toBeVisible();
+    await expect(ajaxLoaderPage.loader).not.toHaveCSS("display", "none");
 
-    await expect(ajaxPage.clickButton).toBeHidden();
-    await expect(ajaxPage.buttonContainer).not.toHaveCSS("display", "block");
+    await expect(ajaxLoaderPage.clickButton).toBeHidden();
+    await expect(ajaxLoaderPage.buttonContainer).not.toHaveCSS("display", "block");
 
     // Wait until the loader disappears
-    await ajaxPage.waitForLoaderToHide();
+    await ajaxLoaderPage.waitForLoaderToHide();
 
     // Verify button visible and loader not visible
-    await expect(ajaxPage.loader).toHaveCSS("display", "none");
+    await expect(ajaxLoaderPage.loader).toHaveCSS("display", "none");
 
-    await expect(ajaxPage.clickButton).toBeVisible();
-    await expect(ajaxPage.buttonContainer).toHaveCSS("display", "block");
+    await expect(ajaxLoaderPage.clickButton).toBeVisible();
+    await expect(ajaxLoaderPage.buttonContainer).toHaveCSS("display", "block");
 
-    await expect(ajaxPage.clickButton).toHaveText("CLICK ME!");
+    await expect(ajaxLoaderPage.clickButton).toHaveText("CLICK ME!");
   });
 
   test("Button when ajax loader disappears works correcly", async ({
-    page
+    ajaxLoaderPage
   }) => {
-    const homePage = new HomePage(page);
-    const ajaxPage = await homePage.openAjaxLoader();
-
     // Wait until the loader disappears
-    await ajaxPage.waitForLoaderToHide();
+    await ajaxLoaderPage.waitForLoaderToHide();
 
-    const clickBttn = ajaxPage.buttonContainer
+    const clickBttn = ajaxLoaderPage.buttonContainer
       .getByRole("paragraph")
       .filter({ hasText: "Click me!" });
 
     // Verify modal is not visible before clicking on button
-    await expect(ajaxPage.modal).toBeHidden();
+    await expect(ajaxLoaderPage.modal).toBeHidden();
 
     // Open modal and verify it is visible
     await clickBttn.click();
-    await expect(ajaxPage.modal).toBeVisible();
+    await expect(ajaxLoaderPage.modal).toBeVisible();
 
     // Verify modal text
-    await expect(ajaxPage.modalTitle).toHaveText("Well Done For Waiting....!!!");
-    await expect(ajaxPage.modalContent).toContainText(
+    await expect(ajaxLoaderPage.modalTitle).toHaveText("Well Done For Waiting....!!!");
+    await expect(ajaxLoaderPage.modalContent).toContainText(
       "The waiting game can be a tricky one;"
     );
 
     // verify modal actions
-    await ajaxPage.modalCloseBtn.click();
-    await expect(ajaxPage.modal).toBeHidden();
+    await ajaxLoaderPage.modalCloseBtn.click();
+    await expect(ajaxLoaderPage.modal).toBeHidden();
 
     await clickBttn.click();
 
-    await ajaxPage.modalXButton.click();
-    await expect(ajaxPage.modal).toBeHidden();
+    await ajaxLoaderPage.modalXButton.click();
+    await expect(ajaxLoaderPage.modal).toBeHidden();
   });
 });

--- a/tests/autocomplete.text.spec.ts
+++ b/tests/autocomplete.text.spec.ts
@@ -1,115 +1,98 @@
-import { test, expect } from "@playwright/test";
-import { HomePage } from "../pages/home.page";
+import { test, expect } from "./fixtures";
 
 test.describe("Autocomplete Text - Only Path", () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto("/");
-  });
-
-  test("Verify title and section elements", async ({ page }) => {
-    const homePage = new HomePage(page);
-    const autoPage = await homePage.openAutocompleteText();
-
+  test("Verify title and section elements", async ({ autocompleteTextPage }) => {
     // Verify navigation
-    await expect(autoPage.page).toHaveURL(
+    await expect(autocompleteTextPage.page).toHaveURL(
       "Autocomplete-TextField/autocomplete-textfield.html"
     );
 
     // Verify items are visible and texts are correct
-    await expect(autoPage.pageTitle).toBeVisible();
-    await expect(autoPage.searchField).toBeVisible();
-    await expect(autoPage.searchField).toHaveAttribute("placeholder", "Food Item");
-    await expect(autoPage.submitButton).toBeVisible();
-    await expect(autoPage.footer).toBeVisible();
+    await expect(autocompleteTextPage.pageTitle).toBeVisible();
+    await expect(autocompleteTextPage.searchField).toBeVisible();
+    await expect(autocompleteTextPage.searchField).toHaveAttribute("placeholder", "Food Item");
+    await expect(autocompleteTextPage.submitButton).toBeVisible();
+    await expect(autocompleteTextPage.footer).toBeVisible();
 
-    await expect(autoPage.pageNavTitle).toContainText(/WebdriverUniversity/);
-    await expect(autoPage.footer).toContainText("Copyright");
+    await expect(autocompleteTextPage.pageNavTitle).toContainText(/WebdriverUniversity/);
+    await expect(autocompleteTextPage.footer).toContainText("Copyright");
 
     // Verify list search is initially hidden
-    await expect(autoPage.resultList).toBeHidden();
-    await expect(autoPage.listItems).toHaveCount(0);
+    await expect(autocompleteTextPage.resultList).toBeHidden();
+    await expect(autocompleteTextPage.listItems).toHaveCount(0);
 
     // Take a snapshot to verify image and components location
-    await expect(autoPage.page).toHaveScreenshot({
+    await expect(autocompleteTextPage.page).toHaveScreenshot({
       fullPage: true
     });
   });
 
   test("Select an option should display a list of elements", async ({
-    page
+    autocompleteTextPage
   }) => {
-    const homePage = new HomePage(page);
-    const autoPage = await homePage.openAutocompleteText();
-
     // Verify autocompletion shows a list between 1 - 10 elements
-    await autoPage.search("A");
-    await expect(autoPage.resultList).toBeVisible();
-    expect((await autoPage.listItems.count()).toString()).toMatch(/^(10|[1-9])$/);
+    await autocompleteTextPage.search("A");
+    await expect(autocompleteTextPage.resultList).toBeVisible();
+    expect((await autocompleteTextPage.listItems.count()).toString()).toMatch(/^(10|[1-9])$/);
 
-    await autoPage.clearSearch();
+    await autocompleteTextPage.clearSearch();
 
-    await autoPage.search("b");
-    await expect(autoPage.resultList).toBeVisible();
-    expect((await autoPage.listItems.count()).toString()).toMatch(/^(10|[1-9])$/);
+    await autocompleteTextPage.search("b");
+    await expect(autocompleteTextPage.resultList).toBeVisible();
+    expect((await autocompleteTextPage.listItems.count()).toString()).toMatch(/^(10|[1-9])$/);
 
-    await autoPage.clearSearch();
+    await autocompleteTextPage.clearSearch();
 
-    await autoPage.search("C");
-    await expect(autoPage.resultList).toBeVisible();
-    expect((await autoPage.listItems.count()).toString()).toMatch(/^(10|[1-9])$/);
+    await autocompleteTextPage.search("C");
+    await expect(autocompleteTextPage.resultList).toBeVisible();
+    expect((await autocompleteTextPage.listItems.count()).toString()).toMatch(/^(10|[1-9])$/);
 
-    await autoPage.clearSearch();
+    await autocompleteTextPage.clearSearch();
 
-    await autoPage.search("d");
-    await expect(autoPage.resultList).toBeVisible();
-    expect((await autoPage.listItems.count()).toString()).toMatch(/^(10|[1-9])$/);
+    await autocompleteTextPage.search("d");
+    await expect(autocompleteTextPage.resultList).toBeVisible();
+    expect((await autocompleteTextPage.listItems.count()).toString()).toMatch(/^(10|[1-9])$/);
   });
 
-  test("Validate Autocomplite search works correctly", async ({ page }) => {
-    const homePage = new HomePage(page);
-    const autoPage = await homePage.openAutocompleteText();
-
+  test("Validate Autocomplite search works correctly", async ({ autocompleteTextPage }) => {
     // Verify autocompletion
-    await autoPage.search("F");
-    await expect(autoPage.resultList).toBeVisible();
-    await expect(autoPage.listItems).toHaveCount(3);
-    await expect(autoPage.listItems).toContainText([/F/, /F/, /F/]);
+    await autocompleteTextPage.search("F");
+    await expect(autocompleteTextPage.resultList).toBeVisible();
+    await expect(autocompleteTextPage.listItems).toHaveCount(3);
+    await expect(autocompleteTextPage.listItems).toContainText([/F/, /F/, /F/]);
 
-    await autoPage.clearSearch();
+    await autocompleteTextPage.clearSearch();
 
-    await autoPage.search("french");
-    await expect(autoPage.resultList).toBeVisible();
-    await expect(autoPage.listItems).toHaveCount(2);
-    await expect(autoPage.listItems).toContainText([/French/, /French/]);
+    await autocompleteTextPage.search("french");
+    await expect(autocompleteTextPage.resultList).toBeVisible();
+    await expect(autocompleteTextPage.listItems).toHaveCount(2);
+    await expect(autocompleteTextPage.listItems).toContainText([/French/, /French/]);
 
-    await autoPage.clearSearch();
+    await autocompleteTextPage.clearSearch();
 
-    await autoPage.search("French d");
-    await expect(autoPage.resultList).toBeVisible();
-    await expect(autoPage.listItems).toHaveCount(1);
-    await expect(autoPage.listItems).toContainText(/French d/);
+    await autocompleteTextPage.search("French d");
+    await expect(autocompleteTextPage.resultList).toBeVisible();
+    await expect(autocompleteTextPage.listItems).toHaveCount(1);
+    await expect(autocompleteTextPage.listItems).toContainText(/French d/);
 
-    await autoPage.clearSearch();
+    await autocompleteTextPage.clearSearch();
 
-    await autoPage.search("French a");
-    await expect(autoPage.resultList).toBeHidden();
-    await expect(autoPage.listItems).toHaveCount(0);
+    await autocompleteTextPage.search("French a");
+    await expect(autocompleteTextPage.resultList).toBeHidden();
+    await expect(autocompleteTextPage.listItems).toHaveCount(0);
   });
 
-  test("Verify submitted option is working correclty", async ({ page }) => {
-    const homePage = new HomePage(page);
-    const autoPage = await homePage.openAutocompleteText();
+  test("Verify submitted option is working correclty", async ({ autocompleteTextPage }) => {
+    // Set option and submit
+    await autocompleteTextPage.selectAndSubmit("Kiwi");
+    await expect(autocompleteTextPage.page).toHaveURL(/food-item=Kiwi/);
 
     // Set option and submit
-    await autoPage.selectAndSubmit("Kiwi");
-    await expect(autoPage.page).toHaveURL(/food-item=Kiwi/);
+    await autocompleteTextPage.selectAndSubmit("Cabbage");
+    await expect(autocompleteTextPage.page).toHaveURL(/food-item=Cabbage/);
 
     // Set option and submit
-    await autoPage.selectAndSubmit("Cabbage");
-    await expect(autoPage.page).toHaveURL(/food-item=Cabbage/);
-
-    // Set option and submit
-    await autoPage.selectAndSubmit("Spaghetti");
-    await expect(autoPage.page).toHaveURL(/food-item=Spaghetti/);
+    await autocompleteTextPage.selectAndSubmit("Spaghetti");
+    await expect(autocompleteTextPage.page).toHaveURL(/food-item=Spaghetti/);
   });
 });

--- a/tests/click.buttons.spec.ts
+++ b/tests/click.buttons.spec.ts
@@ -1,22 +1,14 @@
-import { test, expect } from "@playwright/test";
-import { HomePage } from "../pages/home.page";
+import { test, expect } from "./fixtures";
 
 test.describe("Click Buttons - Only Path", () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto("/");
-  });
-
   test("Page URL, Heading, Title and Copywright should be correct", async ({
-    page
+    clickButtonsPage
   }) => {
-    const homePage = new HomePage(page);
-    const clickBttnPage = await homePage.openButtonClicks();
-
     // Verify Header Title exists
-    await expect(clickBttnPage.headerTitle).toContainText(/WebdriverUniversity.com/);
+    await expect(clickButtonsPage.headerTitle).toContainText(/WebdriverUniversity.com/);
 
     // Verify Page Title exists and is correct
-    await expect(clickBttnPage.pageHeading).toBeVisible();
+    await expect(clickButtonsPage.pageHeading).toBeVisible();
 
     // Define expected section/button titles and page sections
     const titles = [
@@ -29,7 +21,7 @@ test.describe("Click Buttons - Only Path", () => {
 
     // Verify each section title and content QTY= 3 are correct
     for (const key in titles) {
-      const clickBox = clickBttnPage.sections.nth(parseInt(key));
+      const clickBox = clickButtonsPage.sections.nth(parseInt(key));
       const textList = clickBox.locator(".section-title > ol > li");
       const buttonText = clickBox.locator(".caption > span");
 
@@ -38,16 +30,13 @@ test.describe("Click Buttons - Only Path", () => {
       await expect(buttonText).toHaveText(buttons[parseInt(key)]);
     }
 
-    // Bug 1 fix: copyrightText is now scoped to clickBttnPage (popup), not the home page
-    await expect(clickBttnPage.copyrightText).toBeVisible();
+    // Bug 1 fix: copyrightText is now scoped to clickButtonsPage (popup), not the home page
+    await expect(clickButtonsPage.copyrightText).toBeVisible();
   });
 
   test("Clicking on all buttons should open a modal and contain expected text", async ({
-    page
+    clickButtonsPage
   }) => {
-    const homePage = new HomePage(page);
-    const clickBttnPage = await homePage.openButtonClicks();
-
     // Define expected texts
     const expectedModalTxts = [
       {
@@ -71,13 +60,13 @@ test.describe("Click Buttons - Only Path", () => {
     // Click on Buttons and verify modal texts
     for (const [key, modalValue] of expectedModalTxts.entries()) {
       // eslint-disable-next-line playwright/no-force-option
-      await clickBttnPage.clickMeButton(key as 0 | 1 | 2).click({ force: true });
-      await expect(clickBttnPage.modalTitles.nth(key)).toHaveText(modalValue.title);
-      await expect(clickBttnPage.modalBodies.nth(key)).toContainText(modalValue.body);
+      await clickButtonsPage.clickMeButton(key as 0 | 1 | 2).click({ force: true });
+      await expect(clickButtonsPage.modalTitles.nth(key)).toHaveText(modalValue.title);
+      await expect(clickButtonsPage.modalBodies.nth(key)).toContainText(modalValue.body);
 
       // eslint-disable-next-line playwright/no-conditional-in-test
       if (modalValue.list) {
-        const modalList = clickBttnPage.modalBodies.locator("ul > li");
+        const modalList = clickButtonsPage.modalBodies.locator("ul > li");
         // eslint-disable-next-line playwright/no-conditional-expect
         await expect(modalList).toHaveText(modalValue.items as string[]);
       }

--- a/tests/contact.us.spec.ts
+++ b/tests/contact.us.spec.ts
@@ -1,29 +1,18 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./fixtures";
 import { faker } from "@faker-js/faker";
-import { HomePage } from "../pages/home.page";
 
 test.describe("Contact Use Tests - Happy Path", () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto("/");
-  });
-
-  test("Verify Contact US Page Header", async ({ page }) => {
-    const homePage = new HomePage(page);
-    const contactPage = await homePage.openContactUs();
-
+  test("Verify Contact US Page Header", async ({ contactUsPage }) => {
     // Verify Header Title exists
-    await expect(contactPage.navTitle).toContainText(/WebdriverUniversity.com/);
+    await expect(contactUsPage.navTitle).toContainText(/WebdriverUniversity.com/);
   });
 
-  test("Submit Form with all fields should work", async ({ page }) => {
-    const homePage = new HomePage(page);
-    const contactPage = await homePage.openContactUs();
-
+  test("Submit Form with all fields should work", async ({ contactUsPage }) => {
     // Verify page URL to contain the contact us
-    await expect(contactPage.page).toHaveURL(/contact-us/i);
+    await expect(contactUsPage.page).toHaveURL(/contact-us/i);
 
     // Fill all Fields
-    await contactPage.fillForm(
+    await contactUsPage.fillForm(
       faker.person.firstName(),
       faker.person.lastName(),
       faker.internet.email({ firstName: faker.person.firstName() }),
@@ -31,25 +20,22 @@ test.describe("Contact Use Tests - Happy Path", () => {
     );
 
     // Submit form
-    await contactPage.submit();
+    await contactUsPage.submit();
 
     //Verify page redirection
-    await expect(contactPage.page).toHaveURL(/contact-form-thank-you/);
+    await expect(contactUsPage.page).toHaveURL(/contact-form-thank-you/);
 
     // Verify Success message form
-    await expect(contactPage.successHeading).toBeVisible();
+    await expect(contactUsPage.successHeading).toBeVisible();
 
     //Verify Animation Exist and is Correct
-    await expect(contactPage.animation).toBeVisible();
-    await expect(contactPage.animationDots).toHaveCount(8);
+    await expect(contactUsPage.animation).toBeVisible();
+    await expect(contactUsPage.animationDots).toHaveCount(8);
   });
 
-  test("Reset form field should blank all of them", async ({ page }) => {
-    const homePage = new HomePage(page);
-    const contactPage = await homePage.openContactUs();
-
+  test("Reset form field should blank all of them", async ({ contactUsPage }) => {
     // Fill all Fields
-    await contactPage.fillForm(
+    await contactUsPage.fillForm(
       faker.person.firstName(),
       faker.person.lastName(),
       faker.internet.email({ firstName: faker.person.firstName() }),
@@ -57,114 +43,101 @@ test.describe("Contact Use Tests - Happy Path", () => {
     );
 
     //Reset fields and verify they should be blank
-    await contactPage.reset();
+    await contactUsPage.reset();
 
-    await expect(contactPage.firstNameField).toHaveText("");
-    await expect(contactPage.lastNameField).toHaveText("");
-    await expect(contactPage.emailField).toHaveText("");
-    await expect(contactPage.commentsField).toHaveText("");
+    await expect(contactUsPage.firstNameField).toHaveText("");
+    await expect(contactUsPage.lastNameField).toHaveText("");
+    await expect(contactUsPage.emailField).toHaveText("");
+    await expect(contactUsPage.commentsField).toHaveText("");
   });
 });
 
 test.describe("Contact Use Tests - Unhappy Path", () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto("/");
-  });
-
   test("Submit Form without Filling any data should show an error", async ({
-    page
+    contactUsPage
   }) => {
-    const homePage = new HomePage(page);
-    const contactPage = await homePage.openContactUs();
-
     // Submit empty form
-    await contactPage.submit();
+    await contactUsPage.submit();
 
     //Validate error QTY and texts
-    await expect(contactPage.errorBreaks).toHaveCount(2);
-    await expect(contactPage.bodyErrors).toContainText("all fields are required");
-    await expect(contactPage.bodyErrors).toContainText("Invalid email address");
+    await expect(contactUsPage.errorBreaks).toHaveCount(2);
+    await expect(contactUsPage.bodyErrors).toContainText("all fields are required");
+    await expect(contactUsPage.bodyErrors).toContainText("Invalid email address");
   });
 
   test("Submit form without any field should show an error", async ({
-    page
+    contactUsPage
   }) => {
-    const homePage = new HomePage(page);
-    const contactPage = await homePage.openContactUs();
-
     // Fill First Name
-    await contactPage.firstNameField.fill(faker.person.firstName());
+    await contactUsPage.firstNameField.fill(faker.person.firstName());
 
     // Submit Form
-    await contactPage.submit();
+    await contactUsPage.submit();
 
     //Validate error QTY and texts
-    await expect(contactPage.errorBreaks).toHaveCount(2);
-    await expect(contactPage.bodyErrors).toContainText("all fields are required");
-    await expect(contactPage.bodyErrors).toContainText("Invalid email address");
+    await expect(contactUsPage.errorBreaks).toHaveCount(2);
+    await expect(contactUsPage.bodyErrors).toContainText("all fields are required");
+    await expect(contactUsPage.bodyErrors).toContainText("Invalid email address");
 
     // Go back to the Contact Us Page
-    await contactPage.goBackToForm();
+    await contactUsPage.goBackToForm();
 
     // Clear first Name Value
-    await contactPage.firstNameField.clear();
+    await contactUsPage.firstNameField.clear();
 
     // Fill Last Name
-    await contactPage.lastNameField.fill(faker.person.lastName());
+    await contactUsPage.lastNameField.fill(faker.person.lastName());
 
     // Submit Form
-    await contactPage.submit();
+    await contactUsPage.submit();
 
     // Validate error QTY and texts
-    await expect(contactPage.errorBreaks).toHaveCount(2);
-    await expect(contactPage.bodyErrors).toContainText("all fields are required");
-    await expect(contactPage.bodyErrors).toContainText("Invalid email address");
+    await expect(contactUsPage.errorBreaks).toHaveCount(2);
+    await expect(contactUsPage.bodyErrors).toContainText("all fields are required");
+    await expect(contactUsPage.bodyErrors).toContainText("Invalid email address");
 
     // Go back to the Contact Us Page
-    await contactPage.goBackToForm();
+    await contactUsPage.goBackToForm();
 
     // Clear Last Name Value
-    await contactPage.lastNameField.clear();
+    await contactUsPage.lastNameField.clear();
 
     // Fill Email Field with a valid Email
-    await contactPage.emailField.fill(
+    await contactUsPage.emailField.fill(
       faker.internet.email({ firstName: faker.person.firstName() })
     );
 
     // Submit Form
-    await contactPage.submit();
+    await contactUsPage.submit();
 
     // Validate error QTY and texts
-    await expect(contactPage.errorBreaks).toHaveCount(1);
-    await expect(contactPage.bodyErrors).toContainText("all fields are required");
-    await expect(contactPage.bodyErrors).not.toContainText("Invalid email address");
+    await expect(contactUsPage.errorBreaks).toHaveCount(1);
+    await expect(contactUsPage.bodyErrors).toContainText("all fields are required");
+    await expect(contactUsPage.bodyErrors).not.toContainText("Invalid email address");
 
     // Go back to the Contact Us Page
-    await contactPage.goBackToForm();
+    await contactUsPage.goBackToForm();
 
     // Clear email Value
-    await contactPage.emailField.clear();
+    await contactUsPage.emailField.clear();
 
     // Fill Comments Field
-    await contactPage.commentsField.fill(faker.lorem.paragraph(3));
+    await contactUsPage.commentsField.fill(faker.lorem.paragraph(3));
 
     // Submit Form
-    await contactPage.submit();
+    await contactUsPage.submit();
 
     // Validate error QTY and texts
-    await expect(contactPage.errorBreaks).toHaveCount(2);
-    await expect(contactPage.bodyErrors).toContainText("all fields are required");
-    await expect(contactPage.bodyErrors).toContainText("Invalid email address");
+    await expect(contactUsPage.errorBreaks).toHaveCount(2);
+    await expect(contactUsPage.bodyErrors).toContainText("all fields are required");
+    await expect(contactUsPage.bodyErrors).toContainText("Invalid email address");
   });
 
   test("Submit all data without a valid email should show the email error", async ({
-    page
+    contactUsPage
   }) => {
-    const homePage = new HomePage(page);
-    const contactPage = await homePage.openContactUs();
-
     // Fill all Fields (Invalid Email)
-    await contactPage.fillForm(
+    await contactUsPage.fillForm(
       faker.person.firstName(),
       faker.person.lastName(),
       faker.person.middleName(),
@@ -172,11 +145,11 @@ test.describe("Contact Use Tests - Unhappy Path", () => {
     );
 
     // Submit form
-    await contactPage.submit();
+    await contactUsPage.submit();
 
     // Validate error QTY and texts
-    await expect(contactPage.errorBreaks).toHaveCount(1);
-    await expect(contactPage.bodyErrors).not.toContainText("all fields are required");
-    await expect(contactPage.bodyErrors).toContainText("Invalid email address");
+    await expect(contactUsPage.errorBreaks).toHaveCount(1);
+    await expect(contactUsPage.bodyErrors).not.toContainText("all fields are required");
+    await expect(contactUsPage.bodyErrors).toContainText("Invalid email address");
   });
 });

--- a/tests/data.tables.buttons.spec.ts
+++ b/tests/data.tables.buttons.spec.ts
@@ -1,59 +1,45 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./fixtures";
 import { faker } from "@faker-js/faker";
-import { HomePage } from "../pages/home.page";
 
 test.describe("Data Tables and Buttons - Only Path", () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto("/");
-  });
-
-  test("Verify URL, sections and footer", async ({ page }) => {
-    const homePage = new HomePage(page);
-    const dataPage = await homePage.openDataTables();
-
+  test("Verify URL, sections and footer", async ({ dataTablesButtonsPage }) => {
     // Verify url
-    await expect(dataPage.page).toHaveURL(/Data-Table/i);
+    await expect(dataTablesButtonsPage.page).toHaveURL(/Data-Table/i);
 
     // Verify Header Title exists
-    await expect(dataPage.headerTitle).toContainText(/WebdriverUniversity/);
+    await expect(dataTablesButtonsPage.headerTitle).toContainText(/WebdriverUniversity/);
 
     // Verify title is visible and exists
-    await expect(dataPage.pageTitle).toBeVisible();
+    await expect(dataTablesButtonsPage.pageTitle).toBeVisible();
 
     // Define sections and verify QTY = 8
-    await expect(dataPage.sections).toHaveCount(8);
+    await expect(dataTablesButtonsPage.sections).toHaveCount(8);
 
     // Verify footer text exists and is visible
-    await expect(dataPage.footer).toContainText("Copyright");
-    await expect(dataPage.footer).toBeVisible();
+    await expect(dataTablesButtonsPage.footer).toContainText("Copyright");
+    await expect(dataTablesButtonsPage.footer).toBeVisible();
   });
 
   // Data Section
 
   test("Data Section - Verify inital state fields are empty", async ({
-    page
+    dataTablesButtonsPage
   }) => {
-    const homePage = new HomePage(page);
-    const dataPage = await homePage.openDataTables();
-
     //Verify initial state
-    await expect(dataPage.firstNameField).toHaveValue("");
-    await expect(dataPage.lastNameField).toHaveValue("");
-    await expect(dataPage.textAreaField).toHaveValue("      ");
+    await expect(dataTablesButtonsPage.firstNameField).toHaveValue("");
+    await expect(dataTablesButtonsPage.lastNameField).toHaveValue("");
+    await expect(dataTablesButtonsPage.textAreaField).toHaveValue("      ");
   });
 
   test("Data Section - Verify Table 1 information is correct", async ({
-    page
+    dataTablesButtonsPage
   }) => {
-    const homePage = new HomePage(page);
-    const dataPage = await homePage.openDataTables();
-
     // Verify it exists and is visible
-    await expect(dataPage.table1).toBeVisible();
+    await expect(dataTablesButtonsPage.table1).toBeVisible();
 
     //  Define table elements
-    const tableHeaders = dataPage.table1.locator("th");
-    const tableValues = dataPage.table1.locator("td");
+    const tableHeaders = dataTablesButtonsPage.table1.locator("th");
+    const tableValues = dataTablesButtonsPage.table1.locator("td");
 
     // Define expected values
     const headers = ["Firstname", "Lastname", "Age"];
@@ -78,17 +64,14 @@ test.describe("Data Tables and Buttons - Only Path", () => {
   });
 
   test("Data Section - Verify Table 2 information is correct", async ({
-    page
+    dataTablesButtonsPage
   }) => {
-    const homePage = new HomePage(page);
-    const dataPage = await homePage.openDataTables();
-
     // Verify it exists and is visible
-    await expect(dataPage.table2).toBeVisible();
+    await expect(dataTablesButtonsPage.table2).toBeVisible();
 
     //  Define table elements
-    const tableHeaders = dataPage.table2.locator("th");
-    const tableValues = dataPage.table2.locator("td");
+    const tableHeaders = dataTablesButtonsPage.table2.locator("th");
+    const tableValues = dataTablesButtonsPage.table2.locator("td");
 
     // Define expected values
     const headers = ["Firstname", "Lastname", "Age"];
@@ -112,46 +95,40 @@ test.describe("Data Tables and Buttons - Only Path", () => {
     await expect(tableValues).toHaveText(values);
   });
 
-  test("Data Section - Verify input values work correcly", async ({ page }) => {
-    const homePage = new HomePage(page);
-    const dataPage = await homePage.openDataTables();
-
+  test("Data Section - Verify input values work correcly", async ({ dataTablesButtonsPage }) => {
     //Define values
     const firstName = faker.person.firstName();
     const lastName = faker.person.lastName();
     const text = faker.lorem.sentence({ min: 2, max: 4 });
 
     // Fill values
-    await dataPage.firstNameField.fill(firstName);
-    await dataPage.lastNameField.fill(lastName);
-    await dataPage.textAreaField.fill(text);
+    await dataTablesButtonsPage.firstNameField.fill(firstName);
+    await dataTablesButtonsPage.lastNameField.fill(lastName);
+    await dataTablesButtonsPage.textAreaField.fill(text);
 
     // Verify values
-    await expect(dataPage.firstNameField).toHaveValue(firstName);
-    await expect(dataPage.lastNameField).toHaveValue(lastName);
-    await expect(dataPage.textAreaField).toHaveValue(text);
+    await expect(dataTablesButtonsPage.firstNameField).toHaveValue(firstName);
+    await expect(dataTablesButtonsPage.lastNameField).toHaveValue(lastName);
+    await expect(dataTablesButtonsPage.textAreaField).toHaveValue(text);
 
     // Delete values
-    await dataPage.firstNameField.clear();
-    await dataPage.lastNameField.clear();
-    await dataPage.textAreaField.clear();
+    await dataTablesButtonsPage.firstNameField.clear();
+    await dataTablesButtonsPage.lastNameField.clear();
+    await dataTablesButtonsPage.textAreaField.clear();
 
     // Verify fields are empty
-    await expect(dataPage.firstNameField).toHaveValue("");
-    await expect(dataPage.lastNameField).toHaveValue("");
-    await expect(dataPage.textAreaField).toHaveValue("");
+    await expect(dataTablesButtonsPage.firstNameField).toHaveValue("");
+    await expect(dataTablesButtonsPage.lastNameField).toHaveValue("");
+    await expect(dataTablesButtonsPage.textAreaField).toHaveValue("");
   });
 
   // BreadCrumb
 
-  test("BreadCrumb Section - Verify title and values", async ({ page }) => {
-    const homePage = new HomePage(page);
-    const dataPage = await homePage.openDataTables();
-
-    await dataPage.breadcrumbSection.scrollIntoViewIfNeeded();
+  test("BreadCrumb Section - Verify title and values", async ({ dataTablesButtonsPage }) => {
+    await dataTablesButtonsPage.breadcrumbSection.scrollIntoViewIfNeeded();
 
     // Define section items
-    const title = dataPage.breadcrumbSection.getByRole("heading", {
+    const title = dataTablesButtonsPage.breadcrumbSection.getByRole("heading", {
       name: "Breadcrumb"
     });
 
@@ -159,18 +136,15 @@ test.describe("Data Tables and Buttons - Only Path", () => {
 
     // Verify texts
     await expect(title).toBeVisible();
-    await expect(dataPage.breadcrumbItems).toHaveText(breadcrumbValues);
+    await expect(dataTablesButtonsPage.breadcrumbItems).toHaveText(breadcrumbValues);
   });
 
-  test("BreadCrumb Section - Verify breadcrumb options", async ({ page }) => {
-    const homePage = new HomePage(page);
-    const dataPage = await homePage.openDataTables();
+  test("BreadCrumb Section - Verify breadcrumb options", async ({ dataTablesButtonsPage }) => {
+    await dataTablesButtonsPage.breadcrumbSection.scrollIntoViewIfNeeded();
 
-    await dataPage.breadcrumbSection.scrollIntoViewIfNeeded();
-
-    const home = dataPage.breadcrumbItems.filter({ hasText: "Home" });
-    const aboutUs = dataPage.breadcrumbItems.filter({ hasText: "About Us" });
-    const contactUs = dataPage.breadcrumbItems.filter({ hasText: "Contact Us" });
+    const home = dataTablesButtonsPage.breadcrumbItems.filter({ hasText: "Home" });
+    const aboutUs = dataTablesButtonsPage.breadcrumbItems.filter({ hasText: "About Us" });
+    const contactUs = dataTablesButtonsPage.breadcrumbItems.filter({ hasText: "Contact Us" });
 
     // Verify options status
     await expect(home.locator("a")).toHaveAttribute("href", "#");
@@ -179,28 +153,25 @@ test.describe("Data Tables and Buttons - Only Path", () => {
 
     // Click on options and verify redirection
     await home.click();
-    await expect(dataPage.page).toHaveURL(/Data-Table/i);
+    await expect(dataTablesButtonsPage.page).toHaveURL(/Data-Table/i);
 
-    await dataPage.breadcrumbSection.scrollIntoViewIfNeeded();
+    await dataTablesButtonsPage.breadcrumbSection.scrollIntoViewIfNeeded();
 
     await aboutUs.click();
-    await expect(dataPage.page).toHaveURL(/Data-Table/i);
+    await expect(dataTablesButtonsPage.page).toHaveURL(/Data-Table/i);
   });
 
   // Badges
 
-  test("Badges Section - Verify title and values", async ({ page }) => {
-    const homePage = new HomePage(page);
-    const dataPage = await homePage.openDataTables();
-
-    await dataPage.badgeSection.scrollIntoViewIfNeeded();
+  test("Badges Section - Verify title and values", async ({ dataTablesButtonsPage }) => {
+    await dataTablesButtonsPage.badgeSection.scrollIntoViewIfNeeded();
 
     // Define section items
-    const title = dataPage.badgeSection.getByRole("heading", {
+    const title = dataTablesButtonsPage.badgeSection.getByRole("heading", {
       name: "Badges"
     });
 
-    const menu = dataPage.badgeMenuItems;
+    const menu = dataTablesButtonsPage.badgeMenuItems;
 
     const deals = menu.filter({ hasText: "Today's Deals" });
     const allProducts = menu.filter({ hasText: "All Products" });
@@ -217,14 +188,11 @@ test.describe("Data Tables and Buttons - Only Path", () => {
 
   //Pagination
 
-  test("Pagination Section - Verify title and values", async ({ page }) => {
-    const homePage = new HomePage(page);
-    const dataPage = await homePage.openDataTables();
-
-    await dataPage.paginationSection.scrollIntoViewIfNeeded();
+  test("Pagination Section - Verify title and values", async ({ dataTablesButtonsPage }) => {
+    await dataTablesButtonsPage.paginationSection.scrollIntoViewIfNeeded();
 
     // Define section items
-    const title = dataPage.paginationSection.getByRole("heading", {
+    const title = dataTablesButtonsPage.paginationSection.getByRole("heading", {
       name: "Pagination"
     });
 
@@ -234,52 +202,46 @@ test.describe("Data Tables and Buttons - Only Path", () => {
     await expect(title).toBeVisible();
 
     // Verify pagination options
-    await expect(dataPage.paginationListItems).toHaveText(expectedOptions);
+    await expect(dataTablesButtonsPage.paginationListItems).toHaveText(expectedOptions);
   });
 
   test("Pagination Section - Verify pagination works correctly", async ({
-    page
+    dataTablesButtonsPage
   }) => {
-    const homePage = new HomePage(page);
-    const dataPage = await homePage.openDataTables();
-
-    await dataPage.paginationSection.scrollIntoViewIfNeeded();
+    await dataTablesButtonsPage.paginationSection.scrollIntoViewIfNeeded();
 
     // Verify pagination works correctly
-    await dataPage.clickPaginationPage(/«/);
-    await expect(dataPage.page).toHaveURL(/Data-Table/i);
-    await dataPage.paginationSection.scrollIntoViewIfNeeded();
+    await dataTablesButtonsPage.clickPaginationPage(/«/);
+    await expect(dataTablesButtonsPage.page).toHaveURL(/Data-Table/i);
+    await dataTablesButtonsPage.paginationSection.scrollIntoViewIfNeeded();
 
     for (let i = 1; i < 6; i++) {
-      await dataPage.clickPaginationPage(i.toString());
+      await dataTablesButtonsPage.clickPaginationPage(i.toString());
       // Bug 3 fix: replaced waitForTimeout(500) with deterministic waitForLoadState
-      await dataPage.page.waitForLoadState("domcontentloaded");
-      await expect(dataPage.page).toHaveURL(/Data-Table/i);
-      await dataPage.paginationSection.scrollIntoViewIfNeeded();
+      await dataTablesButtonsPage.page.waitForLoadState("domcontentloaded");
+      await expect(dataTablesButtonsPage.page).toHaveURL(/Data-Table/i);
+      await dataTablesButtonsPage.paginationSection.scrollIntoViewIfNeeded();
     }
 
-    await dataPage.clickPaginationPage(/»/);
-    await expect(dataPage.page).toHaveURL(/Data-Table/i);
-    await dataPage.paginationSection.scrollIntoViewIfNeeded();
+    await dataTablesButtonsPage.clickPaginationPage(/»/);
+    await expect(dataTablesButtonsPage.page).toHaveURL(/Data-Table/i);
+    await dataTablesButtonsPage.paginationSection.scrollIntoViewIfNeeded();
   });
 
   // Table
 
-  test("Table Section - Verify title and Table Values", async ({ page }) => {
-    const homePage = new HomePage(page);
-    const dataPage = await homePage.openDataTables();
-
-    await dataPage.tableSection.scrollIntoViewIfNeeded();
+  test("Table Section - Verify title and Table Values", async ({ dataTablesButtonsPage }) => {
+    await dataTablesButtonsPage.tableSection.scrollIntoViewIfNeeded();
 
     // Define section Items
-    const title = dataPage.tableSection.getByRole("heading", {
+    const title = dataTablesButtonsPage.tableSection.getByRole("heading", {
       name: "Table"
     });
 
-    const table = dataPage.tableSection
+    const table = dataTablesButtonsPage.tableSection
       .getByRole("table")
       .locator("th")
-      .or(dataPage.tableSection.locator("td"));
+      .or(dataTablesButtonsPage.tableSection.locator("td"));
 
     const tableValues = [
       "#",
@@ -304,33 +266,30 @@ test.describe("Data Tables and Buttons - Only Path", () => {
   // Button & States
 
   test("Button & States Section - Verify title and section Values", async ({
-    page
+    dataTablesButtonsPage
   }) => {
-    const homePage = new HomePage(page);
-    const dataPage = await homePage.openDataTables();
-
-    await dataPage.buttonStatesSection.scrollIntoViewIfNeeded();
+    await dataTablesButtonsPage.buttonStatesSection.scrollIntoViewIfNeeded();
 
     // Define section Items
-    const title = dataPage.buttonStatesSection.getByRole("heading", {
+    const title = dataTablesButtonsPage.buttonStatesSection.getByRole("heading", {
       name: "Buttons & States"
     });
 
-    const linkBttn = dataPage.buttonStatesSection.getByRole("button", { name: "Link" });
-    const buttonBttn = dataPage.buttonStatesSection
+    const linkBttn = dataTablesButtonsPage.buttonStatesSection.getByRole("button", { name: "Link" });
+    const buttonBttn = dataTablesButtonsPage.buttonStatesSection
       .getByRole("button", { name: /Button/ })
       .first();
-    const inputBttn = dataPage.buttonStatesSection.getByRole("button", { name: "Input" });
-    const submitBttn = dataPage.buttonStatesSection.getByRole("button", { name: "Submit" });
-    const resetBttn = dataPage.buttonStatesSection.getByRole("button", { name: "Reset" });
-    const dangerBttn = dataPage.buttonStatesSection.getByRole("button", { name: "Danger" });
-    const warningBttn = dataPage.buttonStatesSection.getByRole("button", { name: "Warning" });
-    const infoBttn = dataPage.buttonStatesSection.getByRole("button", { name: "Info" });
-    const alertBttn = dataPage.buttonStatesSection.getByRole("button", { name: "Alert" });
-    const button1Bttn = dataPage.buttonStatesSection.getByRole("button", { name: "Button-1" });
-    const button2Bttn = dataPage.buttonStatesSection.getByRole("button", { name: "Button-2" });
-    const button3Bttn = dataPage.buttonStatesSection.getByRole("button", { name: "Button-3" });
-    const button4Bttn = dataPage.buttonStatesSection.getByRole("button", { name: "Button-4" });
+    const inputBttn = dataTablesButtonsPage.buttonStatesSection.getByRole("button", { name: "Input" });
+    const submitBttn = dataTablesButtonsPage.buttonStatesSection.getByRole("button", { name: "Submit" });
+    const resetBttn = dataTablesButtonsPage.buttonStatesSection.getByRole("button", { name: "Reset" });
+    const dangerBttn = dataTablesButtonsPage.buttonStatesSection.getByRole("button", { name: "Danger" });
+    const warningBttn = dataTablesButtonsPage.buttonStatesSection.getByRole("button", { name: "Warning" });
+    const infoBttn = dataTablesButtonsPage.buttonStatesSection.getByRole("button", { name: "Info" });
+    const alertBttn = dataTablesButtonsPage.buttonStatesSection.getByRole("button", { name: "Alert" });
+    const button1Bttn = dataTablesButtonsPage.buttonStatesSection.getByRole("button", { name: "Button-1" });
+    const button2Bttn = dataTablesButtonsPage.buttonStatesSection.getByRole("button", { name: "Button-2" });
+    const button3Bttn = dataTablesButtonsPage.buttonStatesSection.getByRole("button", { name: "Button-3" });
+    const button4Bttn = dataTablesButtonsPage.buttonStatesSection.getByRole("button", { name: "Button-4" });
 
     // Verify elements exist and are visible
     await expect(title).toBeVisible();
@@ -351,30 +310,27 @@ test.describe("Data Tables and Buttons - Only Path", () => {
   });
 
   test("Button & States Section - Verify normal buttons click interactions work correctly", async ({
-    page
+    dataTablesButtonsPage
   }) => {
-    const homePage = new HomePage(page);
-    const dataPage = await homePage.openDataTables();
+    await dataTablesButtonsPage.buttonStatesSection.scrollIntoViewIfNeeded();
 
-    await dataPage.buttonStatesSection.scrollIntoViewIfNeeded();
-
-    const linkBttn = dataPage.buttonStatesSection.getByRole("button", { name: "Link" });
-    const buttonBttn = dataPage.buttonStatesSection
+    const linkBttn = dataTablesButtonsPage.buttonStatesSection.getByRole("button", { name: "Link" });
+    const buttonBttn = dataTablesButtonsPage.buttonStatesSection
       .getByRole("button", { name: /Button/ })
       .first();
-    const inputBttn = dataPage.buttonStatesSection.getByRole("button", { name: "Input" });
-    const submitBttn = dataPage.buttonStatesSection.getByRole("button", { name: "Submit" });
-    const resetBttn = dataPage.buttonStatesSection.getByRole("button", { name: "Reset" });
-    const dangerBttn = dataPage.buttonStatesSection.getByRole("button", { name: "Danger" });
-    const warningBttn = dataPage.buttonStatesSection.getByRole("button", { name: "Warning" });
-    const infoBttn = dataPage.buttonStatesSection.getByRole("button", { name: "Info" });
-    const alertBttn = dataPage.buttonStatesSection.getByRole("button", { name: "Alert" });
+    const inputBttn = dataTablesButtonsPage.buttonStatesSection.getByRole("button", { name: "Input" });
+    const submitBttn = dataTablesButtonsPage.buttonStatesSection.getByRole("button", { name: "Submit" });
+    const resetBttn = dataTablesButtonsPage.buttonStatesSection.getByRole("button", { name: "Reset" });
+    const dangerBttn = dataTablesButtonsPage.buttonStatesSection.getByRole("button", { name: "Danger" });
+    const warningBttn = dataTablesButtonsPage.buttonStatesSection.getByRole("button", { name: "Warning" });
+    const infoBttn = dataTablesButtonsPage.buttonStatesSection.getByRole("button", { name: "Info" });
+    const alertBttn = dataTablesButtonsPage.buttonStatesSection.getByRole("button", { name: "Alert" });
 
     await expect(linkBttn).toBeEnabled();
     await linkBttn.click();
-    await expect(dataPage.page).toHaveURL(/index.html#/i);
+    await expect(dataTablesButtonsPage.page).toHaveURL(/index.html#/i);
 
-    await dataPage.buttonStatesSection.scrollIntoViewIfNeeded();
+    await dataTablesButtonsPage.buttonStatesSection.scrollIntoViewIfNeeded();
 
     await expect(buttonBttn).toBeEnabled();
     await buttonBttn.click();
@@ -401,17 +357,14 @@ test.describe("Data Tables and Buttons - Only Path", () => {
   });
 
   test("Button & States Section - Verify enabled buttons click interactions work correctly", async ({
-    page
+    dataTablesButtonsPage
   }) => {
-    const homePage = new HomePage(page);
-    const dataPage = await homePage.openDataTables();
+    await dataTablesButtonsPage.buttonStatesSection.scrollIntoViewIfNeeded();
 
-    await dataPage.buttonStatesSection.scrollIntoViewIfNeeded();
-
-    const dangerBttn = dataPage.buttonStatesSection.getByRole("button", { name: "Danger" });
-    const warningBttn = dataPage.buttonStatesSection.getByRole("button", { name: "Warning" });
-    const infoBttn = dataPage.buttonStatesSection.getByRole("button", { name: "Info" });
-    const alertBttn = dataPage.buttonStatesSection.getByRole("button", { name: "Alert" });
+    const dangerBttn = dataTablesButtonsPage.buttonStatesSection.getByRole("button", { name: "Danger" });
+    const warningBttn = dataTablesButtonsPage.buttonStatesSection.getByRole("button", { name: "Warning" });
+    const infoBttn = dataTablesButtonsPage.buttonStatesSection.getByRole("button", { name: "Info" });
+    const alertBttn = dataTablesButtonsPage.buttonStatesSection.getByRole("button", { name: "Alert" });
 
     await expect(dangerBttn).not.toHaveClass(/disabled/);
     await dangerBttn.click();
@@ -426,17 +379,14 @@ test.describe("Data Tables and Buttons - Only Path", () => {
   });
 
   test("Button & States Section - Verify active buttons click interactions work correctly", async ({
-    page
+    dataTablesButtonsPage
   }) => {
-    const homePage = new HomePage(page);
-    const dataPage = await homePage.openDataTables();
+    await dataTablesButtonsPage.buttonStatesSection.scrollIntoViewIfNeeded();
 
-    await dataPage.buttonStatesSection.scrollIntoViewIfNeeded();
-
-    const button1Bttn = dataPage.buttonStatesSection.getByRole("button", { name: "Button-1" });
-    const button2Bttn = dataPage.buttonStatesSection.getByRole("button", { name: "Button-2" });
-    const button3Bttn = dataPage.buttonStatesSection.getByRole("button", { name: "Button-3" });
-    const button4Bttn = dataPage.buttonStatesSection.getByRole("button", { name: "Button-4" });
+    const button1Bttn = dataTablesButtonsPage.buttonStatesSection.getByRole("button", { name: "Button-1" });
+    const button2Bttn = dataTablesButtonsPage.buttonStatesSection.getByRole("button", { name: "Button-2" });
+    const button3Bttn = dataTablesButtonsPage.buttonStatesSection.getByRole("button", { name: "Button-3" });
+    const button4Bttn = dataTablesButtonsPage.buttonStatesSection.getByRole("button", { name: "Button-4" });
 
     // Verify initial state
     await expect(button1Bttn).toHaveClass(/active/);
@@ -482,22 +432,19 @@ test.describe("Data Tables and Buttons - Only Path", () => {
   // Random Text
 
   test("Random Text Section - Verify title and texts are correct", async ({
-    page
+    dataTablesButtonsPage
   }) => {
-    const homePage = new HomePage(page);
-    const dataPage = await homePage.openDataTables();
-
-    await dataPage.randomTextSection.scrollIntoViewIfNeeded();
+    await dataTablesButtonsPage.randomTextSection.scrollIntoViewIfNeeded();
 
     // Define section items
-    const title = dataPage.randomTextSection.getByRole("heading", {
+    const title = dataTablesButtonsPage.randomTextSection.getByRole("heading", {
       name: "Random Text"
     });
 
-    const paragraph1 = dataPage.randomTextSection.getByRole("paragraph").first();
-    const paragraph2 = dataPage.randomTextSection.getByRole("paragraph").last();
+    const paragraph1 = dataTablesButtonsPage.randomTextSection.getByRole("paragraph").first();
+    const paragraph2 = dataTablesButtonsPage.randomTextSection.getByRole("paragraph").last();
 
-    const footerParagraph = dataPage.randomTextSection.locator("footer");
+    const footerParagraph = dataTablesButtonsPage.randomTextSection.locator("footer");
 
     // Verify texts and classes
     await expect(title).toBeVisible();
@@ -520,21 +467,18 @@ test.describe("Data Tables and Buttons - Only Path", () => {
   // Lists
 
   test("List Section - Verify section title and list values", async ({
-    page
+    dataTablesButtonsPage
   }) => {
-    const homePage = new HomePage(page);
-    const dataPage = await homePage.openDataTables();
-
-    await dataPage.listSection.scrollIntoViewIfNeeded();
+    await dataTablesButtonsPage.listSection.scrollIntoViewIfNeeded();
 
     // Define section items
-    const title = dataPage.listSection.getByRole("heading", {
+    const title = dataTablesButtonsPage.listSection.getByRole("heading", {
       name: "Lists"
     });
 
-    const coffeeList = dataPage.listSection.getByRole("list").first().locator("li");
-    const fruitsList = dataPage.listSection.getByRole("list").nth(1).locator("li");
-    const jobsList = dataPage.listSection.getByRole("list").nth(2).locator("li");
+    const coffeeList = dataTablesButtonsPage.listSection.getByRole("list").first().locator("li");
+    const fruitsList = dataTablesButtonsPage.listSection.getByRole("list").nth(1).locator("li");
+    const jobsList = dataTablesButtonsPage.listSection.getByRole("list").nth(2).locator("li");
 
     const expectedCoffeeList = ["Coffee", "Tea", "Milk", "Espresso", "Sugar"];
     const expectedFruitsList = [

--- a/tests/dropdown.buttons.spec.ts
+++ b/tests/dropdown.buttons.spec.ts
@@ -1,20 +1,12 @@
-import { test, expect } from "@playwright/test";
-import { HomePage } from "../pages/home.page";
+import { test, expect } from "./fixtures";
 
 test.describe("Dropdown, Checkboxes & Radio Buttons - Only Path", () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto("/");
-  });
-
-  test("Verify Page Header, Title, sections and footer", async ({ page }) => {
-    const homePage = new HomePage(page);
-    const bttnsPage = await homePage.openDropdownButtons();
-
+  test("Verify Page Header, Title, sections and footer", async ({ dropdownButtonsPage }) => {
     // Verify Header Title exists
-    await expect(bttnsPage.navTitle).toContainText(/WebdriverUniversity.com/);
+    await expect(dropdownButtonsPage.navTitle).toContainText(/WebdriverUniversity.com/);
 
     // Verify title
-    const title = bttnsPage.page.locator("#main-header");
+    const title = dropdownButtonsPage.page.locator("#main-header");
 
     await expect(title).toContainText(
       "Dropdown Menu(s), Checkboxe(s) & Radio Button(s)"
@@ -22,7 +14,7 @@ test.describe("Dropdown, Checkboxes & Radio Buttons - Only Path", () => {
     await expect(title).toBeVisible();
 
     // Verify section QTY = 4 and titles
-    await expect(bttnsPage.sections).toHaveCount(4);
+    await expect(dropdownButtonsPage.sections).toHaveCount(4);
 
     const sectionTitles = [
       "Dropdown Menu(s)",
@@ -32,29 +24,26 @@ test.describe("Dropdown, Checkboxes & Radio Buttons - Only Path", () => {
     ];
 
     for (const titleValue of sectionTitles) {
-      const sectionTitle = bttnsPage.sections.getByRole("heading");
+      const sectionTitle = dropdownButtonsPage.sections.getByRole("heading");
       await expect(
         sectionTitle.nth(sectionTitles.indexOf(titleValue))
       ).toHaveText(titleValue);
     }
 
-    await expect(bttnsPage.footer).toContainText("Copyright");
-    await expect(bttnsPage.footer).toBeVisible();
+    await expect(dropdownButtonsPage.footer).toContainText("Copyright");
+    await expect(dropdownButtonsPage.footer).toBeVisible();
   });
 
   test("Dropdown Manu(s) values are correct and work correclty", async ({
-    page
+    dropdownButtonsPage
   }) => {
-    const homePage = new HomePage(page);
-    const bttnsPage = await homePage.openDropdownButtons();
-
     // Validate dropdown QTY = 3
-    await expect(bttnsPage.dropdowns).toHaveCount(3);
+    await expect(dropdownButtonsPage.dropdowns).toHaveCount(3);
 
     // Define test dropdowns and their data
-    const dropdown1 = bttnsPage.dropdowns.nth(0);
-    const dropdown2 = bttnsPage.dropdowns.nth(1);
-    const dropdown3 = bttnsPage.dropdowns.nth(2);
+    const dropdown1 = dropdownButtonsPage.dropdowns.nth(0);
+    const dropdown2 = dropdownButtonsPage.dropdowns.nth(1);
+    const dropdown3 = dropdownButtonsPage.dropdowns.nth(2);
 
     const values1 = ["JAVA", "C#", "Python", "SQL"];
     const values2 = ["Eclipse", "Maven", "TestNG", "JUnit"];
@@ -137,19 +126,16 @@ test.describe("Dropdown, Checkboxes & Radio Buttons - Only Path", () => {
   });
 
   test("Checkboxe(s)values are correct and work correclty", async ({
-    page
+    dropdownButtonsPage
   }) => {
-    const homePage = new HomePage(page);
-    const bttnsPage = await homePage.openDropdownButtons();
-
     // Validate checkboxes QTY = 4
-    await expect(bttnsPage.checkboxes).toHaveCount(4);
+    await expect(dropdownButtonsPage.checkboxes).toHaveCount(4);
 
     // Define test checkboxes and verify their data
-    const checkbox1 = bttnsPage.checkboxes.nth(0);
-    const checkbox2 = bttnsPage.checkboxes.nth(1);
-    const checkbox3 = bttnsPage.checkboxes.nth(2);
-    const checkbox4 = bttnsPage.checkboxes.nth(3);
+    const checkbox1 = dropdownButtonsPage.checkboxes.nth(0);
+    const checkbox2 = dropdownButtonsPage.checkboxes.nth(1);
+    const checkbox3 = dropdownButtonsPage.checkboxes.nth(2);
+    const checkbox4 = dropdownButtonsPage.checkboxes.nth(3);
 
     await expect(checkbox1).toHaveValue(/Option-1/i);
     await expect(checkbox2).toHaveValue(/Option-2/i);
@@ -184,19 +170,16 @@ test.describe("Dropdown, Checkboxes & Radio Buttons - Only Path", () => {
     await expect(checkbox4).not.toBeChecked();
   });
 
-  test("Radio Button(s) are correct and work correclty", async ({ page }) => {
-    const homePage = new HomePage(page);
-    const bttnsPage = await homePage.openDropdownButtons();
-
+  test("Radio Button(s) are correct and work correclty", async ({ dropdownButtonsPage }) => {
     // Validate radio buttons QTY = 5
-    await expect(bttnsPage.radioButtons).toHaveCount(5);
+    await expect(dropdownButtonsPage.radioButtons).toHaveCount(5);
 
     // Define test radio buttons and verify their data
-    const radioButton1 = bttnsPage.radioButtons.nth(0);
-    const radioButton2 = bttnsPage.radioButtons.nth(1);
-    const radioButton3 = bttnsPage.radioButtons.nth(2);
-    const radioButton4 = bttnsPage.radioButtons.nth(3);
-    const radioButton5 = bttnsPage.radioButtons.nth(4);
+    const radioButton1 = dropdownButtonsPage.radioButtons.nth(0);
+    const radioButton2 = dropdownButtonsPage.radioButtons.nth(1);
+    const radioButton3 = dropdownButtonsPage.radioButtons.nth(2);
+    const radioButton4 = dropdownButtonsPage.radioButtons.nth(3);
+    const radioButton5 = dropdownButtonsPage.radioButtons.nth(4);
 
     await expect(radioButton1).toHaveValue("green");
     await expect(radioButton2).toHaveValue("blue");
@@ -254,13 +237,10 @@ test.describe("Dropdown, Checkboxes & Radio Buttons - Only Path", () => {
   });
 
   test("Selected & Disabled are correct and work correclty", async ({
-    page
+    dropdownButtonsPage
   }) => {
-    const homePage = new HomePage(page);
-    const bttnsPage = await homePage.openDropdownButtons();
-
-    const radioButtons = bttnsPage.selectedDisabledRadioButtons;
-    const dropdown = bttnsPage.selectedDisabledDropdown;
+    const radioButtons = dropdownButtonsPage.selectedDisabledRadioButtons;
+    const dropdown = dropdownButtonsPage.selectedDisabledDropdown;
 
     // Verify radio and dropdown QTYs
     await expect(radioButtons).toHaveCount(3);

--- a/tests/file.upload.spec.ts
+++ b/tests/file.upload.spec.ts
@@ -1,40 +1,29 @@
-import { test, expect } from "@playwright/test";
-import { HomePage } from "../pages/home.page";
+import { test, expect } from "./fixtures";
 import path from "path";
 
 test.describe("File Upload - Happy Path", () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto("/");
-  });
-
-  test("Verify Section and values", async ({ page }) => {
-    const homePage = new HomePage(page);
-    const uploadPage = await homePage.openFileUpload();
-
+  test("Verify Section and values", async ({ fileUploadPage }) => {
     // Verify navigation
-    await expect(uploadPage.page).toHaveURL("/File-Upload/index.html");
+    await expect(fileUploadPage.page).toHaveURL("/File-Upload/index.html");
 
     // Verify items are visible and have correct values
-    await expect(uploadPage.pageTitle).toBeVisible();
-    await expect(uploadPage.subtitle).toBeVisible();
-    await expect(uploadPage.fileInput).toBeVisible();
-    await expect(uploadPage.submitButton).toBeVisible();
-    await expect(uploadPage.footer).toBeVisible();
+    await expect(fileUploadPage.pageTitle).toBeVisible();
+    await expect(fileUploadPage.subtitle).toBeVisible();
+    await expect(fileUploadPage.fileInput).toBeVisible();
+    await expect(fileUploadPage.submitButton).toBeVisible();
+    await expect(fileUploadPage.footer).toBeVisible();
 
-    await expect(uploadPage.pageNavTitle).toContainText(/File Upload/);
-    await expect(uploadPage.footer).toContainText("Copyright");
+    await expect(fileUploadPage.pageNavTitle).toContainText(/File Upload/);
+    await expect(fileUploadPage.footer).toContainText("Copyright");
   });
 
   test("Upload a file and submit it should work correclty", async ({
-    page
+    fileUploadPage
   }) => {
-    const homePage = new HomePage(page);
-    const uploadPage = await homePage.openFileUpload();
-
     //Define dialog event (alert) before clicking on the button
     //Grab alert message to assert afterwards
     let successMessage: string = "";
-    uploadPage.page.on("dialog", async (dialog) => {
+    fileUploadPage.page.on("dialog", async (dialog) => {
       successMessage = dialog.message();
       expect(successMessage).toContain("Your file has now been uploaded!");
       await dialog.accept();
@@ -44,24 +33,21 @@ test.describe("File Upload - Happy Path", () => {
     const fileName = "image.png";
     const filePath: string = path.join(__dirname, `../images/${fileName}`);
 
-    await uploadPage.uploadFile(filePath);
-    await uploadPage.submit();
+    await fileUploadPage.uploadFile(filePath);
+    await fileUploadPage.submit();
 
-    await expect(uploadPage.page).toHaveURL(
+    await expect(fileUploadPage.page).toHaveURL(
       `/File-Upload/index.html?filename=${fileName}`
     );
   });
 
   test("Latest file uploaded and submitted is the submitted one", async ({
-    page
+    fileUploadPage
   }) => {
-    const homePage = new HomePage(page);
-    const uploadPage = await homePage.openFileUpload();
-
     //Define dialog event (alert) before clicking on the button
     //Grab alert message to assert afterwards
     let successMessage: string = "";
-    uploadPage.page.on("dialog", async (dialog) => {
+    fileUploadPage.page.on("dialog", async (dialog) => {
       successMessage = dialog.message();
       expect(successMessage).toContain("Your file has now been uploaded!");
       await dialog.accept();
@@ -73,40 +59,33 @@ test.describe("File Upload - Happy Path", () => {
     const filePath: string = path.join(__dirname, `../images/${fileName}`);
     const filePath2: string = path.join(__dirname, `../images/${fileName2}`);
 
-    await uploadPage.uploadFile(filePath);
-    await uploadPage.uploadFile(filePath2);
+    await fileUploadPage.uploadFile(filePath);
+    await fileUploadPage.uploadFile(filePath2);
 
-    await uploadPage.submit();
+    await fileUploadPage.submit();
 
-    await expect(uploadPage.page).toHaveURL(
+    await expect(fileUploadPage.page).toHaveURL(
       `/File-Upload/index.html?filename=${fileName2}`
     );
   });
 });
 
 test.describe("File Upload - Unhappy Path", () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto("/");
-  });
-
   test("Submit without uploading a file should show an error", async ({
-    page
+    fileUploadPage
   }) => {
-    const homePage = new HomePage(page);
-    const uploadPage = await homePage.openFileUpload();
-
     //Define dialog event (alert) before clicking on the button
     //Grab alert message to assert afterwards
     let errorMessage: string = "";
-    uploadPage.page.on("dialog", async (dialog) => {
+    fileUploadPage.page.on("dialog", async (dialog) => {
       errorMessage = dialog.message();
       expect(errorMessage).toContain("You need to select a file to upload!");
       await dialog.accept();
     });
 
     // Submit
-    await uploadPage.submit();
+    await fileUploadPage.submit();
 
-    await expect(uploadPage.page).toHaveURL(`/File-Upload/index.html?filename=`);
+    await expect(fileUploadPage.page).toHaveURL(`/File-Upload/index.html?filename=`);
   });
 });

--- a/tests/fixtures/index.ts
+++ b/tests/fixtures/index.ts
@@ -1,0 +1,111 @@
+import { test as base } from "@playwright/test";
+import { HomePage } from "../../pages/home.page";
+import { ActionsPage } from "../../pages/actions.page";
+import { AjaxLoaderPage } from "../../pages/ajax.loader.page";
+import { AutocompleteTextPage } from "../../pages/autocomplete.text.page";
+import { ClickButtonsPage } from "../../pages/click.buttons.page";
+import { ContactUsPage } from "../../pages/contact.us.page";
+import { DataTablesButtonsPage } from "../../pages/data.tables.buttons.page";
+import { DropdownButtonsPage } from "../../pages/dropdown.buttons.page";
+import { FileUploadPage } from "../../pages/file.upload.page";
+import { HiddenElementsPage } from "../../pages/hidden.elements.page";
+import { IFramePage } from "../../pages/iframe.page";
+import { LoginPortalPage } from "../../pages/login.portal.page";
+import { PageObjectModelPage } from "../../pages/page.object.model.page";
+import { PopupAlertsPage } from "../../pages/popup.alerts.page";
+import { ScrollingAroundPage } from "../../pages/scrolling.around.page";
+import { TextAffectsPage } from "../../pages/text.affects.page";
+import { ToDoListPage } from "../../pages/to.do.list.page";
+
+type AppFixtures = {
+  homePage: HomePage;
+  actionsPage: ActionsPage;
+  ajaxLoaderPage: AjaxLoaderPage;
+  autocompleteTextPage: AutocompleteTextPage;
+  clickButtonsPage: ClickButtonsPage;
+  contactUsPage: ContactUsPage;
+  dataTablesButtonsPage: DataTablesButtonsPage;
+  dropdownButtonsPage: DropdownButtonsPage;
+  fileUploadPage: FileUploadPage;
+  hiddenElementsPage: HiddenElementsPage;
+  iframePage: IFramePage;
+  loginPortalPage: LoginPortalPage;
+  pageObjectModelPage: PageObjectModelPage;
+  popupAlertsPage: PopupAlertsPage;
+  scrollingAroundPage: ScrollingAroundPage;
+  textAffectsPage: TextAffectsPage;
+  toDoListPage: ToDoListPage;
+};
+
+export const test = base.extend<AppFixtures>({
+  homePage: async ({ page }, use) => {
+    await page.goto("/");
+    await use(new HomePage(page));
+  },
+
+  actionsPage: async ({ homePage }, use) => {
+    await use(await homePage.openActions());
+  },
+
+  ajaxLoaderPage: async ({ homePage }, use) => {
+    await use(await homePage.openAjaxLoader());
+  },
+
+  autocompleteTextPage: async ({ homePage }, use) => {
+    await use(await homePage.openAutocompleteText());
+  },
+
+  clickButtonsPage: async ({ homePage }, use) => {
+    await use(await homePage.openButtonClicks());
+  },
+
+  contactUsPage: async ({ homePage }, use) => {
+    await use(await homePage.openContactUs());
+  },
+
+  dataTablesButtonsPage: async ({ homePage }, use) => {
+    await use(await homePage.openDataTables());
+  },
+
+  dropdownButtonsPage: async ({ homePage }, use) => {
+    await use(await homePage.openDropdownButtons());
+  },
+
+  fileUploadPage: async ({ homePage }, use) => {
+    await use(await homePage.openFileUpload());
+  },
+
+  hiddenElementsPage: async ({ homePage }, use) => {
+    await use(await homePage.openHiddenElements());
+  },
+
+  iframePage: async ({ homePage }, use) => {
+    await use(await homePage.openIFrame());
+  },
+
+  loginPortalPage: async ({ homePage }, use) => {
+    await use(await homePage.openLoginPortal());
+  },
+
+  pageObjectModelPage: async ({ homePage }, use) => {
+    await use(await homePage.openPageObjectModel());
+  },
+
+  popupAlertsPage: async ({ homePage }, use) => {
+    await use(await homePage.openPopupAlerts());
+  },
+
+  scrollingAroundPage: async ({ homePage }, use) => {
+    await use(await homePage.openScrollingAround());
+  },
+
+  textAffectsPage: async ({ homePage }, use) => {
+    await use(await homePage.openTextAffects());
+  },
+
+  toDoListPage: async ({ homePage }, use) => {
+    await use(await homePage.openToDoList());
+  },
+});
+
+export { expect } from "@playwright/test";

--- a/tests/hidden.elements.spec.ts
+++ b/tests/hidden.elements.spec.ts
@@ -1,91 +1,74 @@
-import { test, expect } from "@playwright/test";
-import { HomePage } from "../pages/home.page";
+import { test, expect } from "./fixtures";
 
 test.describe("Hidden Elements - Only Path", () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto("/");
-  });
-
-  test("Verify URL, sections and footer", async ({ page }) => {
-    const homePage = new HomePage(page);
-    const hiddenPage = await homePage.openHiddenElements();
-
+  test("Verify URL, sections and footer", async ({ hiddenElementsPage }) => {
     // Verify url
-    await expect(hiddenPage.page).toHaveURL(/Hidden-Elements/i);
+    await expect(hiddenElementsPage.page).toHaveURL(/Hidden-Elements/i);
 
     // Verify Header Title exists
-    await expect(hiddenPage.headerTitle).toContainText(/WebdriverUniversity/);
+    await expect(hiddenElementsPage.headerTitle).toContainText(/WebdriverUniversity/);
 
     // Verify title is visible and exists
-    await expect(hiddenPage.pageTitle).toBeVisible();
+    await expect(hiddenElementsPage.pageTitle).toBeVisible();
 
     // Define sections and verify QTY 3
-    await expect(hiddenPage.sections).toHaveCount(3);
+    await expect(hiddenElementsPage.sections).toHaveCount(3);
 
     // Verify footer text exists and is visible
-    await expect(hiddenPage.footer).toContainText("Copyright");
-    await expect(hiddenPage.footer).toBeVisible();
+    await expect(hiddenElementsPage.footer).toContainText("Copyright");
+    await expect(hiddenElementsPage.footer).toBeVisible();
   });
 
   test("No displayed section shows no element and work correctly", async ({
-    page
+    hiddenElementsPage
   }) => {
-    const homePage = new HomePage(page);
-    const hiddenPage = await homePage.openHiddenElements();
-
-    await expect(hiddenPage.notDisplayedSection).toBeVisible();
+    await expect(hiddenElementsPage.notDisplayedSection).toBeVisible();
 
     // Bug 2 fix: dead code `const modal = page.getByRole("dialog")` removed
     // Verify no displayed element
-    await expect(hiddenPage.notDisplayedButton).toBeAttached();
-    await expect(hiddenPage.notDisplayedButton).toBeHidden();
+    await expect(hiddenElementsPage.notDisplayedButton).toBeAttached();
+    await expect(hiddenElementsPage.notDisplayedButton).toBeHidden();
   });
 
   test("Visibility Hidden section shows no element and work correctly", async ({
-    page
+    hiddenElementsPage
   }) => {
-    const homePage = new HomePage(page);
-    const hiddenPage = await homePage.openHiddenElements();
-
-    await expect(hiddenPage.visibilityHiddenSection).toBeVisible();
+    await expect(hiddenElementsPage.visibilityHiddenSection).toBeVisible();
 
     // Verify no displayed element
-    await expect(hiddenPage.hiddenButton).toBeAttached();
-    await expect(hiddenPage.hiddenButton).toBeHidden();
+    await expect(hiddenElementsPage.hiddenButton).toBeAttached();
+    await expect(hiddenElementsPage.hiddenButton).toBeHidden();
   });
 
   test("Zero Opacity Section should show an element, open a modal and work correcly", async ({
-    page
+    hiddenElementsPage
   }) => {
-    const homePage = new HomePage(page);
-    const hiddenPage = await homePage.openHiddenElements();
-
-    await expect(hiddenPage.zeroOpacitySection).toBeVisible();
+    await expect(hiddenElementsPage.zeroOpacitySection).toBeVisible();
 
     // Verify Opacity button
-    await expect(hiddenPage.opacityButton).toBeAttached();
-    await expect(hiddenPage.opacityButton).toBeVisible();
+    await expect(hiddenElementsPage.opacityButton).toBeAttached();
+    await expect(hiddenElementsPage.opacityButton).toBeVisible();
 
     const listItems = ["Drag & Drop", "Hover & Click", "Click & Hold...."];
 
     // Verify Inital State
-    await expect(hiddenPage.modal).toBeHidden();
+    await expect(hiddenElementsPage.modal).toBeHidden();
 
     // Open the modal and verify items
-    await hiddenPage.opacityButton.click();
+    await hiddenElementsPage.opacityButton.click();
 
-    await expect(hiddenPage.modal).toBeVisible();
-    await expect(hiddenPage.modalTitle).toBeVisible();
-    await expect(hiddenPage.modalContent).toBeVisible();
-    await expect(hiddenPage.modalList).toHaveText(listItems);
+    await expect(hiddenElementsPage.modal).toBeVisible();
+    await expect(hiddenElementsPage.modalTitle).toBeVisible();
+    await expect(hiddenElementsPage.modalContent).toBeVisible();
+    await expect(hiddenElementsPage.modalList).toHaveText(listItems);
 
     // Verify close icon and button work correctly
-    await hiddenPage.modalCloseBtn.click();
-    await expect(hiddenPage.modal).toBeHidden();
+    await hiddenElementsPage.modalCloseBtn.click();
+    await expect(hiddenElementsPage.modal).toBeHidden();
 
-    await hiddenPage.opacityButton.click();
+    await hiddenElementsPage.opacityButton.click();
 
-    await hiddenPage.modalCloseIcon.click();
-    await expect(hiddenPage.modal).toBeHidden();
+    await hiddenElementsPage.modalCloseIcon.click();
+    await expect(hiddenElementsPage.modal).toBeHidden();
   });
 });

--- a/tests/home.page.spec.ts
+++ b/tests/home.page.spec.ts
@@ -1,23 +1,14 @@
-import { test, expect } from "@playwright/test";
-import { HomePage } from "../pages/home.page";
+import { test, expect } from "./fixtures";
 
 test.describe("Home Page Tests - Only Path", () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto("/");
-  });
-
-  test("Verify Home Page Header", async ({ page }) => {
-    const homePage = new HomePage(page);
-
+  test("Verify Home Page Header", async ({ homePage }) => {
     // Verify Header title and redirection
     await expect(homePage.navTitle).toContainText(/WebdriverUniversity.com/);
     await homePage.navTitle.click();
-    expect(page.url()).toContain("https://webdriveruniversity.com");
+    expect(homePage.page.url()).toContain("https://webdriveruniversity.com");
   });
 
-  test("Verify Discount, and Course Text/Links", async ({ page }) => {
-    const homePage = new HomePage(page);
-
+  test("Verify Discount, and Course Text/Links", async ({ homePage }) => {
     // Set expected outputs
     const titlesAndURLs = [
       {
@@ -73,14 +64,12 @@ test.describe("Home Page Tests - Only Path", () => {
 
       expect(linkTitles[key]).toBe(value.title);
       await homePage.courseLinks.nth(key).click();
-      expect(page.url()).toContain(value.url);
-      await page.goBack();
+      expect(homePage.page.url()).toContain(value.url);
+      await homePage.page.goBack();
     }
   });
 
-  test("Verify Home Section Quantities and Texts", async ({ page }) => {
-    const homePage = new HomePage(page);
-
+  test("Verify Home Section Quantities and Texts", async ({ homePage }) => {
     // Set expected sections
     const expectedSections = [
       "CONTACT US",

--- a/tests/iframe.spec.ts
+++ b/tests/iframe.spec.ts
@@ -1,19 +1,11 @@
 /* eslint-disable playwright/no-conditional-expect */
 /* eslint-disable playwright/no-conditional-in-test */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./fixtures";
 import { faker } from "@faker-js/faker";
-import { HomePage } from "../pages/home.page";
 
 test.describe("Iframe - Only Path", () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto("/");
-  });
-
   test.describe("IFrame Page", () => {
-    test("Verify URL, frame existance and footer", async ({ page }) => {
-      const homePage = new HomePage(page);
-      const iframePage = await homePage.openIFrame();
-
+    test("Verify URL, frame existance and footer", async ({ iframePage }) => {
       // Verify page URL
       await expect(iframePage.page).toHaveURL(/IFrame/i);
 
@@ -35,10 +27,7 @@ test.describe("Iframe - Only Path", () => {
         }
       });
 
-      test("Verify Section Navigation", async ({ page }) => {
-        const homePage = new HomePage(page);
-        const iframePage = await homePage.openIFrame();
-
+      test("Verify Section Navigation", async ({ iframePage }) => {
         // Verify initial state
         await expect(iframePage.homeSection).toBeVisible();
         await expect(iframePage.productSection).not.toBeAttached();
@@ -59,10 +48,7 @@ test.describe("Iframe - Only Path", () => {
         await expect(iframePage.contactTitle).toBeVisible();
       });
 
-      test("Image Container list should work correctly", async ({ page }) => {
-        const homePage = new HomePage(page);
-        const iframePage = await homePage.openIFrame();
-
+      test("Image Container list should work correctly", async ({ iframePage }) => {
         // Verify Image Slides and Selection count
         await expect(iframePage.imageSlides).toHaveCount(3);
         await expect(iframePage.imageDots).toHaveCount(3);
@@ -91,11 +77,8 @@ test.describe("Iframe - Only Path", () => {
       });
 
       test("Image Container buttons should work correctly", async ({
-        page
+        iframePage
       }) => {
-        const homePage = new HomePage(page);
-        const iframePage = await homePage.openIFrame();
-
         await expect(iframePage.imageSlides).toHaveCount(3);
 
         await expect(iframePage.imageSlides.nth(0)).toHaveClass("item active");
@@ -124,11 +107,8 @@ test.describe("Iframe - Only Path", () => {
       });
 
       test("Verify Section Qty, titles, stars, buttons and texts", async ({
-        page
+        iframePage
       }) => {
-        const homePage = new HomePage(page);
-        const iframePage = await homePage.openIFrame();
-
         // Define menu values
         const menuValues = ["Home", "Our Products", "Contact Us"];
 
@@ -179,10 +159,7 @@ test.describe("Iframe - Only Path", () => {
         }
       });
 
-      test("Verify modal contents and buttons", async ({ page }) => {
-        const homePage = new HomePage(page);
-        const iframePage = await homePage.openIFrame();
-
+      test("Verify modal contents and buttons", async ({ iframePage }) => {
         await iframePage.findOutMoreBtn.click();
 
         await expect(iframePage.homeModal).toBeVisible();
@@ -209,20 +186,14 @@ test.describe("Iframe - Only Path", () => {
   });
 
   test.describe("IFrame - Our Products", () => {
-    test("Verify Header", async ({ page }) => {
-      const homePage = new HomePage(page);
-      const iframePage = await homePage.openIFrame();
-
+    test("Verify Header", async ({ iframePage }) => {
       await iframePage.productsTab.click();
 
       // Verify page header
       await expect(iframePage.productHeaderTitle).toContainText(/WebDriver/);
     });
 
-    test("Verify Section Navigations", async ({ page }) => {
-      const homePage = new HomePage(page);
-      const iframePage = await homePage.openIFrame();
-
+    test("Verify Section Navigations", async ({ iframePage }) => {
       // Open contact section
       await iframePage.productsTab.click();
 
@@ -246,10 +217,7 @@ test.describe("Iframe - Only Path", () => {
       await expect(iframePage.contactTitle).toBeVisible();
     });
 
-    test("Verify Product Sections and modals", async ({ page }) => {
-      const homePage = new HomePage(page);
-      const iframePage = await homePage.openIFrame();
-
+    test("Verify Product Sections and modals", async ({ iframePage }) => {
       await iframePage.productsTab.click();
 
       // Verify Product Section QTY = 8
@@ -295,19 +263,13 @@ test.describe("Iframe - Only Path", () => {
 
   test.describe("IFrame - Contact Us", () => {
     test.describe("IFrame - Contact Us - Happy Path", () => {
-      test("Verify Contact US Page Header", async ({ page }) => {
-        const homePage = new HomePage(page);
-        const iframePage = await homePage.openIFrame();
-
+      test("Verify Contact US Page Header", async ({ iframePage }) => {
         // Verify Header Title exists (displayed on home tab by default)
         const headerTitle = iframePage.frame.locator("#nav-title");
         await expect(headerTitle).toContainText(/WebdriverUniversity.com/);
       });
 
-      test("Submit Form with all fields should work", async ({ page }) => {
-        const homePage = new HomePage(page);
-        const iframePage = await homePage.openIFrame();
-
+      test("Submit Form with all fields should work", async ({ iframePage }) => {
         await iframePage.contactTab.click();
 
         // Fill all Fields
@@ -329,10 +291,7 @@ test.describe("Iframe - Only Path", () => {
         await expect(iframePage.contactAnimationDots).toHaveCount(8);
       });
 
-      test("Reset form field should blank all of them", async ({ page }) => {
-        const homePage = new HomePage(page);
-        const iframePage = await homePage.openIFrame();
-
+      test("Reset form field should blank all of them", async ({ iframePage }) => {
         await iframePage.contactTab.click();
 
         // Fill all Fields
@@ -355,11 +314,8 @@ test.describe("Iframe - Only Path", () => {
 
     test.describe("IFrame - Contact Us - Unhappy Path", () => {
       test("Submit Form without Filling any data should show an error", async ({
-        page
+        iframePage
       }) => {
-        const homePage = new HomePage(page);
-        const iframePage = await homePage.openIFrame();
-
         await iframePage.contactTab.click();
 
         // Submit empty form
@@ -372,11 +328,8 @@ test.describe("Iframe - Only Path", () => {
       });
 
       test("Submit form without any field should show an error", async ({
-        page
+        iframePage
       }) => {
-        const homePage = new HomePage(page);
-        const iframePage = await homePage.openIFrame();
-
         await iframePage.contactTab.click();
 
         // Fill First Name
@@ -436,11 +389,8 @@ test.describe("Iframe - Only Path", () => {
       });
 
       test("Submit all data without a valid email should show the email error", async ({
-        page
+        iframePage
       }) => {
-        const homePage = new HomePage(page);
-        const iframePage = await homePage.openIFrame();
-
         await iframePage.contactTab.click();
 
         // Fill all Fields (Invalid Email)

--- a/tests/login.portal.spec.ts
+++ b/tests/login.portal.spec.ts
@@ -1,25 +1,17 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./fixtures";
 import { faker } from "@faker-js/faker";
-import { HomePage } from "../pages/home.page";
 
 test.describe("Login Portal Tests - Happy Path", () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto("/");
-  });
-
   test("Log in with valid credentials should show an alert success message", async ({
-    page
+    loginPortalPage
   }) => {
-    const homePage = new HomePage(page);
-    const loginPage = await homePage.openLoginPortal();
-
     // Verify page URL to contain the login portal
-    await expect(loginPage.page).toHaveURL(/login-portal/i);
+    await expect(loginPortalPage.page).toHaveURL(/login-portal/i);
 
     //Define dialog event (alert) before clicking on the button
     //Grab alert message to assert afterwards
     let successMessage: string = "";
-    loginPage.page.on("dialog", async (dialog) => {
+    loginPortalPage.page.on("dialog", async (dialog) => {
       // Grab allert message
       successMessage = dialog.message();
 
@@ -29,80 +21,67 @@ test.describe("Login Portal Tests - Happy Path", () => {
     });
 
     // Fill out the details and submit form (will fire then on() event)
-    await loginPage.login(
+    await loginPortalPage.login(
       process.env.USERNAME as string,
       process.env.PASSWORD as string
     );
   });
 
   test("Login Page Animation should contain 10 animation bubbles", async ({
-    page
+    loginPortalPage
   }) => {
-    const homePage = new HomePage(page);
-    const loginPage = await homePage.openLoginPortal();
-
-    await expect(loginPage.animationBubbles).toHaveCount(10);
+    await expect(loginPortalPage.animationBubbles).toHaveCount(10);
   });
 });
 
 test.describe("Login Portal Tests - Unhappy Path", () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto("/");
-  });
-
   test("Submit empty/incomplete form should show an alert error message", async ({
-    page
+    loginPortalPage
   }) => {
-    const homePage = new HomePage(page);
-    const loginPage = await homePage.openLoginPortal();
-
     // Define dialog event (alert) before clicking on the button
     // Grab alert message to assert afterwards
     // Called every time an alert is opened
     let errorMessage: string = "";
 
-    loginPage.page.on("dialog", async (dialog) => {
+    loginPortalPage.page.on("dialog", async (dialog) => {
       errorMessage = dialog.message();
       expect(errorMessage).toContain("validation failed");
       await dialog.accept();
     });
 
     // Fill username and submit
-    await loginPage.usernameField.fill(process.env.USERNAME as string);
-    await loginPage.loginButton.click();
+    await loginPortalPage.usernameField.fill(process.env.USERNAME as string);
+    await loginPortalPage.loginButton.click();
 
     // Wait page to load after closing alert
-    await loginPage.page.waitForLoadState();
+    await loginPortalPage.page.waitForLoadState();
 
     // Fill password and submit
-    await loginPage.passwordField.fill(process.env.PASSWORD as string);
-    await loginPage.loginButton.click();
+    await loginPortalPage.passwordField.fill(process.env.PASSWORD as string);
+    await loginPortalPage.loginButton.click();
 
     // Wait page to load after closing alert
-    await loginPage.page.waitForLoadState();
+    await loginPortalPage.page.waitForLoadState();
 
     // Submit empty form
-    await loginPage.loginButton.click();
+    await loginPortalPage.loginButton.click();
   });
 
   test("Submit invalid credentials should show an alert error message", async ({
-    page
+    loginPortalPage
   }) => {
-    const homePage = new HomePage(page);
-    const loginPage = await homePage.openLoginPortal();
-
     // Define dialog event (alert) before clicking on the button
     // Grab alert message to assert afterwards
     let errorMessage: string = "";
 
-    loginPage.page.on("dialog", async (dialog) => {
+    loginPortalPage.page.on("dialog", async (dialog) => {
       errorMessage = dialog.message();
       expect(errorMessage).toContain("validation failed");
       await dialog.accept();
     });
 
     // Fill out the details and submit form (will fire then on() event)
-    await loginPage.login(
+    await loginPortalPage.login(
       faker.person.firstName(),
       faker.person.jobArea()
     );

--- a/tests/page.object.model.spec.ts
+++ b/tests/page.object.model.spec.ts
@@ -1,72 +1,58 @@
 /* eslint-disable playwright/no-conditional-expect */
 /* eslint-disable playwright/no-conditional-in-test */
-import { test, expect } from "@playwright/test";
-import { HomePage } from "../pages/home.page";
+import { test, expect } from "./fixtures";
 
 test.describe("Page Object Model - Only path", () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto("/");
-  });
-
   test.describe("Home", () => {
-    test("Verify Page Object Model Page Header", async ({ page }) => {
-      const homePage = new HomePage(page);
-      const pomPage = await homePage.openPageObjectModel();
-
-      await expect(pomPage.page).toHaveURL(/Page-Object-Model/);
+    test("Verify Page Object Model Page Header", async ({ pageObjectModelPage }) => {
+      await expect(pageObjectModelPage.page).toHaveURL(/Page-Object-Model/);
 
       // Verify Header Title exists
-      await expect(pomPage.headerTitle).toContainText(/WebdriverUniversity.com/);
+      await expect(pageObjectModelPage.headerTitle).toContainText(/WebdriverUniversity.com/);
     });
 
-    test("Verify Section Navigation", async ({ page }) => {
-      const homePage = new HomePage(page);
-      const pomPage = await homePage.openPageObjectModel();
-
+    test("Verify Section Navigation", async ({ pageObjectModelPage }) => {
       // Validate Product Navigation
-      await pomPage.goToProducts();
-      await expect(pomPage.page).toHaveURL(/products/);
+      await pageObjectModelPage.goToProducts();
+      await expect(pageObjectModelPage.page).toHaveURL(/products/);
 
-      await pomPage.goBack();
+      await pageObjectModelPage.goBack();
 
       // Validate Contact Us Navigation
-      await pomPage.goToContact();
-      await expect(pomPage.page).toHaveURL(/contactus/);
+      await pageObjectModelPage.goToContact();
+      await expect(pageObjectModelPage.page).toHaveURL(/contactus/);
 
-      await pomPage.goBack();
+      await pageObjectModelPage.goBack();
 
       // Validate Home Navigation
-      await pomPage.goToHome();
-      await expect(pomPage.page).toHaveURL(/index/);
+      await pageObjectModelPage.goToHome();
+      await expect(pageObjectModelPage.page).toHaveURL(/index/);
     });
 
-    test("Image Container list should work correctly", async ({ page }) => {
-      const homePage = new HomePage(page);
-      const pomPage = await homePage.openPageObjectModel();
-
+    test("Image Container list should work correctly", async ({ pageObjectModelPage }) => {
       // Verify Image Slides and Selection count
-      await expect(pomPage.imageSlides).toHaveCount(3);
-      await expect(pomPage.imageDots).toHaveCount(3);
+      await expect(pageObjectModelPage.imageSlides).toHaveCount(3);
+      await expect(pageObjectModelPage.imageDots).toHaveCount(3);
 
-      const imageCount = (await pomPage.imageSlides.count()) - 1;
+      const imageCount = (await pageObjectModelPage.imageSlides.count()) - 1;
 
       // Verify image selection and slides when clicking on all options
       for (let imageIndex = 0; imageIndex <= imageCount; imageIndex++) {
-        const imageSlide = pomPage.imageSlides.nth(imageIndex);
-        const imageDot = pomPage.imageDots.nth(imageIndex);
+        const imageSlide = pageObjectModelPage.imageSlides.nth(imageIndex);
+        const imageDot = pageObjectModelPage.imageDots.nth(imageIndex);
 
         // Inital state verify the other selections are not active
         if (imageIndex == 0) {
-          await expect(pomPage.imageSlides.nth(imageIndex + 1)).not.toHaveClass(
+          await expect(pageObjectModelPage.imageSlides.nth(imageIndex + 1)).not.toHaveClass(
             "active"
           );
-          await expect(pomPage.imageDots.nth(imageIndex + 1)).not.toHaveClass(
+          await expect(pageObjectModelPage.imageDots.nth(imageIndex + 1)).not.toHaveClass(
             "active"
           );
-          await expect(pomPage.imageSlides.nth(imageIndex + 2)).not.toHaveClass(
+          await expect(pageObjectModelPage.imageSlides.nth(imageIndex + 2)).not.toHaveClass(
             "active"
           );
-          await expect(pomPage.imageDots.nth(imageIndex + 2)).not.toHaveClass(
+          await expect(pageObjectModelPage.imageDots.nth(imageIndex + 2)).not.toHaveClass(
             "active"
           );
         }
@@ -79,43 +65,37 @@ test.describe("Page Object Model - Only path", () => {
       }
     });
 
-    test("Image Container buttons should work correctly", async ({ page }) => {
-      const homePage = new HomePage(page);
-      const pomPage = await homePage.openPageObjectModel();
+    test("Image Container buttons should work correctly", async ({ pageObjectModelPage }) => {
+      await expect(pageObjectModelPage.imageSlides).toHaveCount(3);
 
-      await expect(pomPage.imageSlides).toHaveCount(3);
+      await expect(pageObjectModelPage.imageSlides.nth(0)).toHaveClass("item active");
+      await expect(pageObjectModelPage.imageSlides.nth(1)).not.toHaveClass("item active");
+      await expect(pageObjectModelPage.imageSlides.nth(2)).not.toHaveClass("item active");
 
-      await expect(pomPage.imageSlides.nth(0)).toHaveClass("item active");
-      await expect(pomPage.imageSlides.nth(1)).not.toHaveClass("item active");
-      await expect(pomPage.imageSlides.nth(2)).not.toHaveClass("item active");
+      await pageObjectModelPage.carouselRight.click();
+      await expect(pageObjectModelPage.imageSlides.nth(0)).not.toHaveClass("item active");
+      await expect(pageObjectModelPage.imageSlides.nth(1)).toHaveClass("item active");
+      await expect(pageObjectModelPage.imageSlides.nth(2)).not.toHaveClass("item active");
 
-      await pomPage.carouselRight.click();
-      await expect(pomPage.imageSlides.nth(0)).not.toHaveClass("item active");
-      await expect(pomPage.imageSlides.nth(1)).toHaveClass("item active");
-      await expect(pomPage.imageSlides.nth(2)).not.toHaveClass("item active");
+      await pageObjectModelPage.carouselRight.click();
+      await expect(pageObjectModelPage.imageSlides.nth(0)).not.toHaveClass("item active");
+      await expect(pageObjectModelPage.imageSlides.nth(1)).not.toHaveClass("item active");
+      await expect(pageObjectModelPage.imageSlides.nth(2)).toHaveClass("item active");
 
-      await pomPage.carouselRight.click();
-      await expect(pomPage.imageSlides.nth(0)).not.toHaveClass("item active");
-      await expect(pomPage.imageSlides.nth(1)).not.toHaveClass("item active");
-      await expect(pomPage.imageSlides.nth(2)).toHaveClass("item active");
+      await pageObjectModelPage.carouselLeft.click();
+      await expect(pageObjectModelPage.imageSlides.nth(0)).not.toHaveClass("item active");
+      await expect(pageObjectModelPage.imageSlides.nth(1)).toHaveClass("item active");
+      await expect(pageObjectModelPage.imageSlides.nth(2)).not.toHaveClass("item active");
 
-      await pomPage.carouselLeft.click();
-      await expect(pomPage.imageSlides.nth(0)).not.toHaveClass("item active");
-      await expect(pomPage.imageSlides.nth(1)).toHaveClass("item active");
-      await expect(pomPage.imageSlides.nth(2)).not.toHaveClass("item active");
-
-      await pomPage.carouselLeft.click();
-      await expect(pomPage.imageSlides.nth(0)).toHaveClass("item active");
-      await expect(pomPage.imageSlides.nth(1)).not.toHaveClass("item active");
-      await expect(pomPage.imageSlides.nth(2)).not.toHaveClass("item active");
+      await pageObjectModelPage.carouselLeft.click();
+      await expect(pageObjectModelPage.imageSlides.nth(0)).toHaveClass("item active");
+      await expect(pageObjectModelPage.imageSlides.nth(1)).not.toHaveClass("item active");
+      await expect(pageObjectModelPage.imageSlides.nth(2)).not.toHaveClass("item active");
     });
 
     test("Verify Section Qty, titles, stars, buttons and texts", async ({
-      page
+      pageObjectModelPage
     }) => {
-      const homePage = new HomePage(page);
-      const pomPage = await homePage.openPageObjectModel();
-
       // Define menu values
       const menuValues = ["Home", "Our Products", "Contact Us"];
 
@@ -146,16 +126,16 @@ test.describe("Page Object Model - Only path", () => {
       ];
 
       // Validate Menu QTY = 3 and Values
-      await expect(pomPage.navMenu).toHaveCount(3);
-      await expect(pomPage.navMenu).toHaveText(menuValues);
+      await expect(pageObjectModelPage.navMenu).toHaveCount(3);
+      await expect(pageObjectModelPage.navMenu).toHaveText(menuValues);
 
       // Validate Section QTY = 4 and Values
-      await expect(pomPage.thumbnailSections).toHaveCount(4);
+      await expect(pageObjectModelPage.thumbnailSections).toHaveCount(4);
 
       for (const [index, section] of sectionContents.entries()) {
         // Define each section title and Content
-        const sectionTitle = pomPage.thumbnailSections.locator(".sub-heading").nth(index);
-        const sectionContent = pomPage.thumbnailSections.locator(".caption").nth(index);
+        const sectionTitle = pageObjectModelPage.thumbnailSections.locator(".sub-heading").nth(index);
+        const sectionContent = pageObjectModelPage.thumbnailSections.locator(".caption").nth(index);
 
         // Verify Title and Content matches the expected values
         await expect(sectionTitle).toHaveText(section.title);
@@ -163,93 +143,81 @@ test.describe("Page Object Model - Only path", () => {
 
         // If section has stars, validate count
         if (section.stars) {
-          const sectionStars = pomPage.thumbnailSections.nth(index).locator(".glyphicon-star");
+          const sectionStars = pageObjectModelPage.thumbnailSections.nth(index).locator(".glyphicon-star");
           expect(await sectionStars.count()).toBe(section.starCount);
         }
       }
     });
 
-    test("Verify modal contents and buttons", async ({ page }) => {
-      const homePage = new HomePage(page);
-      const pomPage = await homePage.openPageObjectModel();
+    test("Verify modal contents and buttons", async ({ pageObjectModelPage }) => {
+      await pageObjectModelPage.findOutMoreBtn.click();
 
-      await pomPage.findOutMoreBtn.click();
+      await expect(pageObjectModelPage.modal).toBeVisible();
+      await expect(pageObjectModelPage.modalTitle).toBeVisible();
+      await expect(pageObjectModelPage.modalContent).toBeVisible();
 
-      await expect(pomPage.modal).toBeVisible();
-      await expect(pomPage.modalTitle).toBeVisible();
-      await expect(pomPage.modalContent).toBeVisible();
+      await pageObjectModelPage.modalAcceptBtn.click();
+      await expect(pageObjectModelPage.modal).toBeHidden();
 
-      await pomPage.modalAcceptBtn.click();
-      await expect(pomPage.modal).toBeHidden();
+      await pageObjectModelPage.findOutMoreBtn.click();
 
-      await pomPage.findOutMoreBtn.click();
+      await pageObjectModelPage.modalCloseBtn.click();
+      await expect(pageObjectModelPage.modal).toBeHidden();
 
-      await pomPage.modalCloseBtn.click();
-      await expect(pomPage.modal).toBeHidden();
+      await pageObjectModelPage.findOutMoreBtn.click();
 
-      await pomPage.findOutMoreBtn.click();
-
-      await pomPage.modalCloseIcon.click();
-      await expect(pomPage.modal).toBeHidden();
+      await pageObjectModelPage.modalCloseIcon.click();
+      await expect(pageObjectModelPage.modal).toBeHidden();
     });
   });
 
   test.describe("Our Products", () => {
-    test("Verify Header", async ({ page }) => {
-      const homePage = new HomePage(page);
-      const pomPage = await homePage.openPageObjectModel();
-
-      await pomPage.goToProducts();
+    test("Verify Header", async ({ pageObjectModelPage }) => {
+      await pageObjectModelPage.goToProducts();
 
       // Verify page header
-      await expect(pomPage.headerTitle).toContainText(/WebDriver/);
+      await expect(pageObjectModelPage.headerTitle).toContainText(/WebDriver/);
     });
 
-    test("Verify Section Navigations", async ({ page }) => {
-      const homePage = new HomePage(page);
-      const pomPage = await homePage.openPageObjectModel();
-
-      await pomPage.goToProducts();
+    test("Verify Section Navigations", async ({ pageObjectModelPage }) => {
+      await pageObjectModelPage.goToProducts();
 
       // Validate Home Navigation
-      await pomPage.goToHome();
-      await expect(pomPage.page).toHaveURL(/index/);
+      await pageObjectModelPage.goToHome();
+      await expect(pageObjectModelPage.page).toHaveURL(/index/);
 
-      await pomPage.goBack();
+      await pageObjectModelPage.goBack();
 
       // Validate Contact Us Navigation
-      await pomPage.goToContact();
-      await expect(pomPage.page).toHaveURL(/contactus/);
+      await pageObjectModelPage.goToContact();
+      await expect(pageObjectModelPage.page).toHaveURL(/contactus/);
 
-      await pomPage.goBack();
+      await pageObjectModelPage.goBack();
 
       // Validate Product Navigation
-      await pomPage.goToProducts();
-      await expect(pomPage.page).toHaveURL(/products/);
+      await pageObjectModelPage.goToProducts();
+      await expect(pageObjectModelPage.page).toHaveURL(/products/);
     });
 
-    test("Verify Product Sections and modals", async ({ page }) => {
-      const homePage = new HomePage(page);
-      const pomPage = await homePage.openPageObjectModel();
-
-      await pomPage.goToProducts();
+    test("Verify Product Sections and modals", async ({ pageObjectModelPage }) => {
+      await pageObjectModelPage.goToProducts();
 
       // Verify Product Section QTY = 8
-      await expect(pomPage.productSections).toHaveCount(8);
+      await expect(pageObjectModelPage.productSections).toHaveCount(8);
 
       // Add sections to an array of sections
       const sectionsBlocks = [
-        pomPage.productLink("Special Offers"),
-        pomPage.productLink("Cameras"),
-        pomPage.productLink("New Laptops"),
-        pomPage.productLink("Used Laptops"),
-        pomPage.productLink("Game Consoles"),
-        pomPage.productLink("Components"),
-        pomPage.productLink("Desktop Systems"),
-        pomPage.productLink("Audio")
+        pageObjectModelPage.productLink("Special Offers"),
+        pageObjectModelPage.productLink("Cameras"),
+        pageObjectModelPage.productLink("New Laptops"),
+        pageObjectModelPage.productLink("Used Laptops"),
+        pageObjectModelPage.productLink("Game Consoles"),
+        pageObjectModelPage.productLink("Components"),
+        pageObjectModelPage.productLink("Desktop Systems"),
+        pageObjectModelPage.productLink("Audio")
       ];
 
-      const modalContent = pomPage.page.getByRole("paragraph").filter({
+      const modalContent = pageObjectModelPage.page.getByRole("paragraph").filter({
         hasText: `Please Note: All orders must be over the value of £50, adding additional coupon codes to the basket are excluded from this offer. To receive 30% off please add the following code to the basket: ${process.env.DISCOUNT}`
       });
 
@@ -257,35 +225,32 @@ test.describe("Page Object Model - Only path", () => {
       for (const block of sectionsBlocks) {
         await block.click();
 
-        await expect(pomPage.modal).toBeVisible();
-        await expect(pomPage.productsModalTitle).toBeVisible();
+        await expect(pageObjectModelPage.modal).toBeVisible();
+        await expect(pageObjectModelPage.productsModalTitle).toBeVisible();
         await expect(modalContent).toBeVisible();
 
-        await pomPage.proceedButton.click();
-        await expect(pomPage.modal).toBeHidden();
+        await pageObjectModelPage.proceedButton.click();
+        await expect(pageObjectModelPage.modal).toBeHidden();
 
         await block.click();
-        await pomPage.modalCloseBtn.click();
-        await expect(pomPage.modal).toBeHidden();
+        await pageObjectModelPage.modalCloseBtn.click();
+        await expect(pageObjectModelPage.modal).toBeHidden();
 
         await block.click();
-        await pomPage.modalCloseIcon.click();
-        await expect(pomPage.modal).toBeHidden();
+        await pageObjectModelPage.modalCloseIcon.click();
+        await expect(pageObjectModelPage.modal).toBeHidden();
       }
     });
   });
 
   test.describe("Contact Us", () => {
-    test("Verify Contact Us navigation and Header", async ({ page }) => {
-      const homePage = new HomePage(page);
-      const pomPage = await homePage.openPageObjectModel();
+    test("Verify Contact Us navigation and Header", async ({ pageObjectModelPage }) => {
+      await pageObjectModelPage.goToContact();
 
-      await pomPage.goToContact();
-
-      await expect(pomPage.page).toHaveURL(/contactus/);
+      await expect(pageObjectModelPage.page).toHaveURL(/contactus/);
 
       // Verify Header Title exists
-      await expect(pomPage.headerTitle).toContainText(/WebdriverUniversity.com/);
+      await expect(pageObjectModelPage.headerTitle).toContainText(/WebdriverUniversity.com/);
     });
   });
 });

--- a/tests/popup.alerts.spec.ts
+++ b/tests/popup.alerts.spec.ts
@@ -1,132 +1,109 @@
-import { test, expect } from "@playwright/test";
-import { HomePage } from "../pages/home.page";
+import { test, expect } from "./fixtures";
 
 test.describe("Pop-Up & Aletrs - only Path", () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto("/");
-  });
-
   test("Verify titles, sections and button visibility and texts", async ({
-    page
+    popupAlertsPage
   }) => {
-    const homePage = new HomePage(page);
-    const popupPage = await homePage.openPopupAlerts();
-
     // Validate Section QTY = 4 and title and footer
-    await expect(popupPage.pageNavTitle).toContainText(/WebdriverUniversity/i);
-    await expect(popupPage.mainTitle).toHaveText("Annoying Popup & Alerts!");
-    await expect(popupPage.sections).toHaveCount(4);
-    await expect(popupPage.footer).toContainText("Copyright");
+    await expect(popupAlertsPage.pageNavTitle).toContainText(/WebdriverUniversity/i);
+    await expect(popupAlertsPage.mainTitle).toHaveText("Annoying Popup & Alerts!");
+    await expect(popupAlertsPage.sections).toHaveCount(4);
+    await expect(popupAlertsPage.footer).toContainText("Copyright");
   });
 
   test("JavaScript Alert is opened when clicking on button and is working correctly", async ({
-    page
+    popupAlertsPage
   }) => {
-    const homePage = new HomePage(page);
-    const popupPage = await homePage.openPopupAlerts();
-
     //Define dialog event (alert) before clicking on the button
     //Grab alert message to assert afterwards
     let successMessage: string = "";
-    popupPage.page.on("dialog", async (dialog) => {
+    popupAlertsPage.page.on("dialog", async (dialog) => {
       successMessage = dialog.message();
       expect(successMessage).toContain("I am an alert box!");
       await dialog.accept();
     });
 
     // Click on button to open the alert
-    await popupPage.jsAlertButton.click();
+    await popupAlertsPage.jsAlertButton.click();
   });
 
   test("Modal Pop-up should appear when clicking on button and work correctly", async ({
-    page
+    popupAlertsPage
   }) => {
-    const homePage = new HomePage(page);
-    const popupPage = await homePage.openPopupAlerts();
-
     // Verify initial state (modal hidden)
-    await expect(popupPage.modal).toBeHidden();
+    await expect(popupAlertsPage.modal).toBeHidden();
 
     // Open modal and verify title and texts to exist and be visible
-    await popupPage.modalButton.click();
+    await popupAlertsPage.modalButton.click();
 
-    await expect(popupPage.modal).toBeVisible();
-    await expect(popupPage.modalTitle).toBeVisible();
-    await expect(popupPage.modalContent).toBeVisible();
+    await expect(popupAlertsPage.modal).toBeVisible();
+    await expect(popupAlertsPage.modalTitle).toBeVisible();
+    await expect(popupAlertsPage.modalContent).toBeVisible();
 
     // Verify close icon and button work correctly
-    await popupPage.modalCloseBtn.click();
-    await expect(popupPage.modal).toBeHidden();
+    await popupAlertsPage.modalCloseBtn.click();
+    await expect(popupAlertsPage.modal).toBeHidden();
 
-    await popupPage.modalButton.click();
+    await popupAlertsPage.modalButton.click();
 
-    await popupPage.modalCloseIcon.click();
-    await expect(popupPage.modal).toBeHidden();
+    await popupAlertsPage.modalCloseIcon.click();
+    await expect(popupAlertsPage.modal).toBeHidden();
   });
 
   test("Ajax Loader Page should be opened when clicking on the Ajax loader button", async ({
-    page
+    popupAlertsPage
   }) => {
-    const homePage = new HomePage(page);
-    const popupPage = await homePage.openPopupAlerts();
-
     // Click on button to open the ajax loader page
-    await popupPage.ajaxButton.click();
+    await popupAlertsPage.ajaxButton.click();
 
-    await expect(popupPage.page).toHaveURL(/Ajax-Loader/);
+    await expect(popupAlertsPage.page).toHaveURL(/Ajax-Loader/);
   });
 
   test("JavaScript Confirm Box (Accept) should be opened when clicking on button and work correcly", async ({
-    page
+    popupAlertsPage
   }) => {
-    const homePage = new HomePage(page);
-    const popupPage = await homePage.openPopupAlerts();
-
     //Define dialog event (alert) before clicking on the button
     let dialogMessage: string = "";
 
-    popupPage.page.on("dialog", async (dialog) => {
+    popupAlertsPage.page.on("dialog", async (dialog) => {
       dialogMessage = dialog.message();
       expect(dialogMessage).toContain("Press a button!");
       dialog.accept();
     });
 
     // Verify initial state
-    await expect(popupPage.confirmResultText).toBeHidden();
+    await expect(popupAlertsPage.confirmResultText).toBeHidden();
 
     // Click on the Confirm box button to open dialog
-    await popupPage.confirmButton.click();
-    await popupPage.page.waitForLoadState();
+    await popupAlertsPage.confirmButton.click();
+    await popupAlertsPage.page.waitForLoadState();
 
     //Verify Section message is shown and correct
-    await expect(popupPage.confirmResultText).toBeVisible();
-    await expect(popupPage.confirmResultText).toHaveText("You pressed OK!");
+    await expect(popupAlertsPage.confirmResultText).toBeVisible();
+    await expect(popupAlertsPage.confirmResultText).toHaveText("You pressed OK!");
   });
 
   test("JavaScript Confirm Box (Dismiss) should be opened when clicking on button and work correcly", async ({
-    page
+    popupAlertsPage
   }) => {
-    const homePage = new HomePage(page);
-    const popupPage = await homePage.openPopupAlerts();
-
     //Define dialog event (alert) before clicking on the button
     let dialogMessage: string = "";
 
-    popupPage.page.on("dialog", async (dialog) => {
+    popupAlertsPage.page.on("dialog", async (dialog) => {
       dialogMessage = dialog.message();
       expect(dialogMessage).toContain("Press a button!");
       dialog.dismiss();
     });
 
     // Verify initial state
-    await expect(popupPage.confirmResultText).toBeHidden();
+    await expect(popupAlertsPage.confirmResultText).toBeHidden();
 
     // Click on the Confirm box button to open dialog
-    await popupPage.confirmButton.click();
-    await popupPage.page.waitForLoadState();
+    await popupAlertsPage.confirmButton.click();
+    await popupAlertsPage.page.waitForLoadState();
 
     //Verify Section message is shown and correct
-    await expect(popupPage.confirmResultText).toBeVisible();
-    await expect(popupPage.confirmResultText).toHaveText("You pressed Cancel!");
+    await expect(popupAlertsPage.confirmResultText).toBeVisible();
+    await expect(popupAlertsPage.confirmResultText).toHaveText("You pressed Cancel!");
   });
 });

--- a/tests/scrolling.around.spec.ts
+++ b/tests/scrolling.around.spec.ts
@@ -1,94 +1,77 @@
-import { test, expect } from "@playwright/test";
-import { HomePage } from "../pages/home.page";
+import { test, expect } from "./fixtures";
 
 test.describe("Scriolling Around - Only Path", () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto("/");
-  });
-
-  test("Verify page header, titles and button texts", async ({ page }) => {
-    const homePage = new HomePage(page);
-    const scrollingPage = await homePage.openScrollingAround();
-
+  test("Verify page header, titles and button texts", async ({ scrollingAroundPage }) => {
     // Verify url and Header title
-    await expect(scrollingPage.page).toHaveURL(/Scrolling/i);
-    await expect(scrollingPage.pageNavTitle).toContainText(/WebDriver/);
+    await expect(scrollingAroundPage.page).toHaveURL(/Scrolling/i);
+    await expect(scrollingAroundPage.pageNavTitle).toContainText(/WebDriver/);
 
     //Verify texts
-    await expect(scrollingPage.mainTitle).toHaveText("Just Scrolling Around!");
+    await expect(scrollingAroundPage.mainTitle).toHaveText("Just Scrolling Around!");
 
-    await expect(scrollingPage.scrollZone1).toContainText("Scroll to me first");
-    await expect(scrollingPage.entriesZone2).toHaveText("0 Entries");
-    await expect(scrollingPage.entriesZone3).toHaveText("0 Entries");
-    await expect(scrollingPage.scrollZone4).toHaveText("Dont forget to scroll to me!");
+    await expect(scrollingAroundPage.scrollZone1).toContainText("Scroll to me first");
+    await expect(scrollingAroundPage.entriesZone2).toHaveText("0 Entries");
+    await expect(scrollingAroundPage.entriesZone3).toHaveText("0 Entries");
+    await expect(scrollingAroundPage.scrollZone4).toHaveText("Dont forget to scroll to me!");
 
-    await expect(scrollingPage.footer).toContainText("Copyright");
+    await expect(scrollingAroundPage.footer).toContainText("Copyright");
   });
 
   test("Scroll Section 1 should work correctly when hovered over", async ({
-    page
+    scrollingAroundPage
   }) => {
-    const homePage = new HomePage(page);
-    const scrollingPage = await homePage.openScrollingAround();
-
     // Verify inital state
-    await expect(scrollingPage.scrollZone1).not.toHaveAttribute(
+    await expect(scrollingAroundPage.scrollZone1).not.toHaveAttribute(
       "style",
       "background: rgb(26, 255, 26); font-size: 24px; text-align: center;"
     );
-    await expect(scrollingPage.scrollZone1).toContainText("Scroll to me first");
+    await expect(scrollingAroundPage.scrollZone1).toContainText("Scroll to me first");
 
     //Scroll to section
-    await scrollingPage.scrollZone1.scrollIntoViewIfNeeded();
-    await scrollingPage.scrollZone1.hover();
+    await scrollingAroundPage.scrollZone1.scrollIntoViewIfNeeded();
+    await scrollingAroundPage.scrollZone1.hover();
 
     // Verify text and style changed
-    await expect(scrollingPage.scrollZone1).toContainText("Well done for scrolling to me!");
-    await expect(scrollingPage.scrollZone1).toHaveAttribute(
+    await expect(scrollingAroundPage.scrollZone1).toContainText("Well done for scrolling to me!");
+    await expect(scrollingAroundPage.scrollZone1).toHaveAttribute(
       "style",
       "background: rgb(26, 255, 26); font-size: 24px; text-align: center;"
     );
   });
 
   test("Entries sections should increase the count when horevered over", async ({
-    page
+    scrollingAroundPage
   }) => {
-    const homePage = new HomePage(page);
-    const scrollingPage = await homePage.openScrollingAround();
-
     // Verify inital state
-    await expect(scrollingPage.entriesZone2).toHaveText("0 Entries");
-    await expect(scrollingPage.entriesZone3).toHaveText("0 Entries");
+    await expect(scrollingAroundPage.entriesZone2).toHaveText("0 Entries");
+    await expect(scrollingAroundPage.entriesZone3).toHaveText("0 Entries");
 
     //Hover over section to simulate scroll
     for (let count = 1; count < 6; count++) {
-      await scrollingPage.entriesZone2.hover();
-      await expect(scrollingPage.entriesZone2).toHaveText(`${count} Entries`);
+      await scrollingAroundPage.entriesZone2.hover();
+      await expect(scrollingAroundPage.entriesZone2).toHaveText(`${count} Entries`);
 
-      await scrollingPage.entriesZone3.hover();
-      await expect(scrollingPage.entriesZone3).toHaveText(`${count} Entries`);
+      await scrollingAroundPage.entriesZone3.hover();
+      await expect(scrollingAroundPage.entriesZone3).toHaveText(`${count} Entries`);
     }
   });
 
   test("Scroll Section 2 should show position where the mouse is when hovered over", async ({
-    page
+    scrollingAroundPage
   }) => {
-    const homePage = new HomePage(page);
-    const scrollingPage = await homePage.openScrollingAround();
-
     // Verify initial state
-    await expect(scrollingPage.scrollZone4).toHaveText("Dont forget to scroll to me!");
-    await expect(scrollingPage.scrollZone4).not.toHaveAttribute(
+    await expect(scrollingAroundPage.scrollZone4).toHaveText("Dont forget to scroll to me!");
+    await expect(scrollingAroundPage.scrollZone4).not.toHaveAttribute(
       "style",
       "text-align: center; font-size: 32px; color: rgb(255, 255, 255); background: black;"
     );
 
     // Hover over the section and verify the coordinates are shown and color changed
     // Bug 5 fix: regex instead of hardcoded "X: 625Y: 816" (viewport-dependent value)
-    await scrollingPage.scrollZone4.scrollIntoViewIfNeeded();
-    await scrollingPage.scrollZone4.hover();
-    await expect(scrollingPage.scrollZone4).toHaveText(/^X: \d+Y: \d+$/);
-    await expect(scrollingPage.scrollZone4).toHaveAttribute(
+    await scrollingAroundPage.scrollZone4.scrollIntoViewIfNeeded();
+    await scrollingAroundPage.scrollZone4.hover();
+    await expect(scrollingAroundPage.scrollZone4).toHaveText(/^X: \d+Y: \d+$/);
+    await expect(scrollingAroundPage.scrollZone4).toHaveAttribute(
       "style",
       "text-align: center; font-size: 32px; color: rgb(255, 255, 255); background: black;"
     );

--- a/tests/text.affects.spec.ts
+++ b/tests/text.affects.spec.ts
@@ -1,16 +1,8 @@
 /* eslint-disable playwright/no-wait-for-timeout */
-import { test, expect } from "@playwright/test";
-import { HomePage } from "../pages/home.page";
+import { test, expect } from "./fixtures";
 
 test.describe("Text Effects - Only path", () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto("/");
-  });
-
-  test("Verify page header, titles and button texts", async ({ page }) => {
-    const homePage = new HomePage(page);
-    const textAffectsPage = await homePage.openTextAffects();
-
+  test("Verify page header, titles and button texts", async ({ textAffectsPage }) => {
     // Verify url
     await expect(textAffectsPage.page).toHaveURL(/Accordion/);
 
@@ -37,11 +29,8 @@ test.describe("Text Effects - Only path", () => {
   });
 
   test("Verify button texts are initially hidden and show when clicking on them", async ({
-    page
+    textAffectsPage
   }) => {
-    const homePage = new HomePage(page);
-    const textAffectsPage = await homePage.openTextAffects();
-
     // Define Buttons
     const manualTestingBttn = textAffectsPage.page.getByRole("button", {
       name: "Manual Testing"
@@ -91,10 +80,7 @@ test.describe("Text Effects - Only path", () => {
     await expect(automationBttn).not.toHaveClass("accordion active");
   });
 
-  test("Verify asyncronous actions generated in page", async ({ page }) => {
-    const homePage = new HomePage(page);
-    const textAffectsPage = await homePage.openTextAffects();
-
+  test("Verify asyncronous actions generated in page", async ({ textAffectsPage }) => {
     // Define Hide elements
     const appearTextBttn = textAffectsPage.page.getByRole("button", {
       name: "Keep Clicking!"

--- a/tests/to.do.list.spec.ts
+++ b/tests/to.do.list.spec.ts
@@ -1,30 +1,19 @@
-import { test, expect } from "@playwright/test";
-import { HomePage } from "../pages/home.page";
+import { test, expect } from "./fixtures";
 
 test.describe("To Do List - Only Path", () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto("/");
-  });
-
-  test("Verify Text and button existance", async ({ page }) => {
-    const homePage = new HomePage(page);
-    const toDoPage = await homePage.openToDoList();
-
+  test("Verify Text and button existance", async ({ toDoListPage }) => {
     // Verify Page URL to contain to do list
-    await expect(toDoPage.page).toHaveURL(/to-do-list/i);
+    await expect(toDoListPage.page).toHaveURL(/to-do-list/i);
 
     // Verify button, field and title exist and are correct
-    await expect(toDoPage.title).toContainText("TO-DO LIST");
-    await expect(toDoPage.plusButton).toBeVisible();
-    await expect(toDoPage.newTodoInput).toBeVisible();
+    await expect(toDoListPage.title).toContainText("TO-DO LIST");
+    await expect(toDoListPage.plusButton).toBeVisible();
+    await expect(toDoListPage.newTodoInput).toBeVisible();
   });
 
   test("Verify initial load have 3 items and button functionality", async ({
-    page
+    toDoListPage
   }) => {
-    const homePage = new HomePage(page);
-    const toDoPage = await homePage.openToDoList();
-
     // Define initial load items, this does not change
     const initialItems = [
       " Go to potion class",
@@ -33,35 +22,32 @@ test.describe("To Do List - Only Path", () => {
     ];
 
     // Verify initial load list QTY = 3 and values
-    await expect(toDoPage.listItems).toHaveCount(3);
-    await expect(toDoPage.listItems).toHaveText(initialItems);
+    await expect(toDoListPage.listItems).toHaveCount(3);
+    await expect(toDoListPage.listItems).toHaveText(initialItems);
 
     // Click on the button and field should be hidden
-    await expect(toDoPage.newTodoInput).toBeVisible();
-    await toDoPage.plusButton.click();
-    await expect(toDoPage.newTodoInput).toBeHidden();
+    await expect(toDoListPage.newTodoInput).toBeVisible();
+    await toDoListPage.plusButton.click();
+    await expect(toDoListPage.newTodoInput).toBeHidden();
 
     // Verify trash icons are enabled and items not completed
-    for (const item of await toDoPage.listItems.all()) {
-      const trashIcon = toDoPage.trashIcon(item);
+    for (const item of await toDoListPage.listItems.all()) {
+      const trashIcon = toDoListPage.trashIcon(item);
       await expect(trashIcon).toBeEnabled();
       await expect(item).not.toHaveClass("completed");
     }
   });
 
-  test("Add or Remove items is working correctly", async ({ page }) => {
-    const homePage = new HomePage(page);
-    const toDoPage = await homePage.openToDoList();
-
+  test("Add or Remove items is working correctly", async ({ toDoListPage }) => {
     // Add new To Do item to the To Do list
-    await toDoPage.addItem("Example 1");
+    await toDoListPage.addItem("Example 1");
 
     // Verify new item is added correctly
-    await expect(toDoPage.listItems.last()).toHaveText("Example 1");
-    await expect(toDoPage.listItems).toHaveCount(4);
+    await expect(toDoListPage.listItems.last()).toHaveText("Example 1");
+    await expect(toDoListPage.listItems).toHaveCount(4);
 
     //define delete items
-    const deleteItem = toDoPage.listItems.nth(0);
+    const deleteItem = toDoListPage.listItems.nth(0);
 
     //Mark the delete item as complete
     await expect(deleteItem).not.toHaveClass("completed");
@@ -69,16 +55,16 @@ test.describe("To Do List - Only Path", () => {
     await expect(deleteItem).toHaveClass("completed");
 
     // Delete the complete item
-    await toDoPage.trashIcon(deleteItem).hover();
-    await toDoPage.trashIcon(deleteItem).click();
+    await toDoListPage.trashIcon(deleteItem).hover();
+    await toDoListPage.trashIcon(deleteItem).click();
 
     // Verify List Count is 3
-    await expect(toDoPage.listItems).toHaveCount(3);
+    await expect(toDoListPage.listItems).toHaveCount(3);
 
     // Define new list items
     const updatedItems = [" Buy new robes", " Practice magic", " Example 1"];
 
     // Verify List items are correct
-    await expect(toDoPage.listItems).toHaveText(updatedItems);
+    await expect(toDoListPage.listItems).toHaveText(updatedItems);
   });
 });


### PR DESCRIPTION
## Summary

- Created `tests/fixtures/index.ts` using `test.extend<AppFixtures>()` to define 17 typed fixtures (one per feature page), eliminating repetitive `beforeEach` boilerplate from every spec
- Refactored all 17 test specs to import `{ test, expect }` from `"./fixtures"` instead of `"@playwright/test"`, removing per-test `HomePage` construction and `open*()` calls
- Updated `README.md` with a full **Custom Fixtures** section: before/after code examples, available fixtures table, and instructions for adding new fixtures

## What changed

**New file — `tests/fixtures/index.ts`**

Central fixture registry using Playwright's `test.extend()` API. The `homePage` fixture navigates to `/` and returns a `HomePage` instance; all 16 feature fixtures depend on `homePage` and call the corresponding `open*()` method to open the feature popup. Since popups open a new `Page` instance, each feature fixture is fully isolated with no shared browser state.

**All 17 specs refactored**

Each spec previously had:
1. A `test.beforeEach` that navigated to `/`
2. `const homePage = new HomePage(page)` inside each test
3. `const featurePage = await homePage.openX()` inside each test
